### PR TITLE
Add JSON schema for protocol and refresh status docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Protocol specification with JSON schema and encryption details
   - Platform-specific README files with setup instructions
 
+#### Added - October 2, 2025
+- **Protocol Validation**: Published JSON Schema for clipboard and control messages (`docs/protocol.schema.json`) to enable automated validation in tooling and test suites
+
 #### Infrastructure
 - Initialized Git repository with comprehensive .gitignore
 - Created MIT license file

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,169 @@
+# Product Requirements Document: Cross-Platform Clipboard Sync
+
+## Project Overview
+- **Project**: Cross-Platform Clipboard Sync
+- **Platforms**: Android (HyperOS 3+) and macOS 26+
+- **Owner**: TBD
+- **Version**: Draft v0.1
+
+## 1. Purpose
+Users frequently move between Xiaomi/HyperOS devices and macOS machines but lack a native universal clipboard. This product will enable real-time, bi-directional clipboard synchronization across devices, supporting both LAN (local network) for speed and efficiency and a cloud fallback for mobility. It should also provide clipboard history on macOS, with rich notifications and cross-format support for text, links, images, and small files.
+
+## 2. Goals & Objectives
+- Enable dual-sync clipboard between Android/HyperOS and macOS.
+- Prioritize LAN-first sync (Wi-Fi / Bonjour / mDNS discovery) with a fallback to cloud relay when no local path is available.
+- Support common clipboard data types:
+  - Plain text
+  - Links/URLs
+  - Images (PNG/JPEG under 1 MB)
+  - Files (≤ 1 MB)
+- Provide native clipboard history on macOS 26, searchable with timestamps.
+- Notify macOS users when a new clipboard item arrives from mobile.
+- Ensure modern, minimal UI/UX, consistent with macOS and Android design guidelines.
+
+## 3. Non-Goals
+- Not designed for very large file transfers (> 1 MB).
+- No guarantee of perfect fidelity for proprietary clipboard formats (e.g., styled RTF from Word).
+
+## 4. Key Features
+
+### 4.1 Dual Sync Engine
+- Android → macOS: Push clipboard updates in real time.
+- macOS → Android: Capture pasteboard changes (NSPasteboard) and push to the Android app.
+- De-duplication logic: prevent infinite ping-pong loops.
+- Configurable update throttling (for example, no more than one update every 300 ms).
+
+### 4.2 Transport Layer
+- **Local network sync**
+  - Use mDNS / Bonjour for discovery.
+  - TLS over WebSocket for direct LAN connection.
+- **Cloud relay (fallback)**
+  - Secure WebSocket via backend relay server.
+  - End-to-end encryption to ensure privacy.
+
+### 4.3 Clipboard Data Support
+- Text/Links/URLs: UTF-8 encoded.
+- Images: Compressed to PNG or JPEG.
+- Files: Base64-encoded small files (< 1 MB).
+
+### 4.4 macOS Features
+- Notification Center integration: Display incoming clipboard updates with previews (for example, text snippet or image thumbnail).
+- Clipboard history UI:
+  - Menu-bar dropdown.
+  - Search/filter by type or date.
+  - Up to N (configurable, default 200) entries stored locally.
+
+### 4.5 Android Features
+- Foreground service to listen to the clipboard.
+- Permissions handling for background clipboard read/write (workarounds for Android restrictions).
+- Simple UI: history, settings (LAN/Cloud priority, encryption key management).
+
+### 4.6 Security & Privacy
+- End-to-end AES-256 encryption of clipboard data.
+- Device pairing via QR code scan (exchange keys over local network).
+- Optional auto-expire clipboard items (for example, delete after X hours).
+
+## 5. Technical Requirements
+
+### macOS Client
+- Language: Swift/SwiftUI + AppKit (NSPasteboard).
+- Background agent + menu-bar app.
+- Notifications via the macOS 26 notification framework.
+
+### Android Client
+- Language: Kotlin.
+- ClipboardManager API.
+- Foreground Service to bypass background restrictions.
+
+### Backend (Cloud Relay)
+- Lightweight WebSocket server (Node.js, Go, or Rust).
+- Stateless design that relays only encrypted payloads.
+- Protocol format:
+
+```json
+{
+  "id": "uuid",
+  "timestamp": "iso8601",
+  "type": "text|link|image|file",
+  "payload": "base64/string",
+  "device": "android|macos"
+}
+```
+
+## 6. User Stories
+1. As a user, I copy a text snippet on my Xiaomi phone, and within 1 s, it appears on my Mac.
+2. As a user, I copy an image (≤ 1 MB) on my Mac, and it syncs to my phone’s clipboard.
+3. As a user, I want a macOS menu-bar app to view my clipboard history and paste from it.
+4. As a user, if I’m away from my LAN, I want the clipboard to still sync via the cloud.
+5. As a user, I want notifications on macOS when a new clipboard item arrives from my phone.
+
+## 7. UX / UI Concepts
+
+### macOS
+- Menu bar icon with clipboard count.
+- History popup with search box and previews.
+
+### Android
+- Clean Material You interface.
+- Switch between LAN/Cloud, manage keys, view history.
+
+## 8. Risks / Challenges
+- Android background clipboard access restrictions (HyperOS may add more).
+- Maintaining performance with image/file transfers.
+- Latency issues if cloud fallback is the only available path.
+- Security: clipboard may contain sensitive data, so encryption must be strong.
+
+## 9. Success Metrics
+- Median sync latency < 1 s (LAN).
+- Error rate < 0.1%.
+- 95% of transfers under 1 MB succeed in < 3 s via cloud.
+- User satisfaction rating ≥ 4.5 in beta test.
+
+## 10. Suggestions for Expansion
+- Add multi-device sync (Mac ↔ multiple phones).
+- Add end-to-end logs and analytics (debug mode).
+- Optionally integrate with iCloud Drive or Google Drive for larger files.
+- Add cross-device search: search clipboard history across all devices.
+
+## 11. UX / UI Wireframes (Conceptual)
+
+### macOS 26 (Menu Bar App + History)
+- **Menu Bar Dropdown**
+  - Top section: Latest clipboard item preview.
+  - Shows icon by type: 📋 text, 🔗 link, 🖼 image, 📄 file.
+  - Hover → “Copy to Clipboard Again.”
+  - Middle section: History list (scrollable, approximately 10–15 recent items).
+  - Each entry: small icon plus truncated text, filename, or thumbnail.
+  - Right-click → options (Copy, Pin, Delete).
+  - Bottom section includes a search bar (filter by keyword, type, or date) and a settings gear.
+- **Notification Center**
+  - Rich preview of new incoming item:
+    - Text → show first 100 characters.
+    - Link → show domain and favicon.
+    - Image → small thumbnail.
+    - File → filename and size.
+
+### Android / HyperOS 3 (App + Foreground Service)
+- **Home Screen**
+  - Header: “Clipboard Sync” with device connection status (LAN / Cloud / Offline).
+  - Large card for the last clipboard item (preview plus “Share to Mac” button if sync fails).
+  - History section: chronological list with type icons, searchable.
+- **Settings Screen**
+  - Toggles: Enable LAN sync / Enable Cloud sync.
+  - Encryption keys management (pair device via QR code).
+  - Data retention settings (history size, auto-delete after N days).
+  - Battery optimization whitelist instructions.
+- **Foreground Service Notification**
+  - Persistent notification: “Clipboard sync active.”
+  - Quick action buttons: Pause, Resume, Push last item.
+
+## 12. Suggested Visual Style
+- macOS: Light/dark mode adaptive, rounded cards, native SF Symbols icons.
+- Android/HyperOS: Material You theming with color-adaptive widgets.
+- Consistency: Use the same symbols for content types (text/link/image/file) across both platforms.
+
+## 13. Future Expansion (UI Hooks)
+- Multi-device support: device list in settings.
+- Drag-and-drop files directly into the menu bar app for instant sharing.
+- Contextual actions: for example, links open directly in browser, images preview fullscreen.
+

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -45,6 +45,19 @@ All messages are JSON objects with the following schema:
 | `type` | Enum | Yes | Message type: `clipboard`, `control` |
 | `payload` | Object | Yes | Type-specific payload data |
 
+### 2.2 JSON Schema Reference
+
+A machine-readable JSON Schema for protocol messages is available in
+[`docs/protocol.schema.json`](./protocol.schema.json). The schema codifies all
+required fields, enumerations, and content-specific constraints so clients and
+test suites can validate payloads automatically. Example validation command:
+
+```bash
+pnpm jsonschema docs/protocol.schema.json payload.json
+```
+
+Any linting tool that supports JSON Schema Draft 2020-12 will work.
+
 ---
 
 ## 3. Clipboard Messages

--- a/docs/protocol.schema.json
+++ b/docs/protocol.schema.json
@@ -1,0 +1,395 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hypo.app/schemas/protocol.schema.json",
+  "title": "Hypo Clipboard Sync Message",
+  "description": "Schema definition for clipboard and control messages exchanged between Hypo clients and relay services.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "timestamp", "version", "type", "payload"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for each message."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp in UTC."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?$",
+      "description": "Protocol version in semantic versioning format (major.minor[.patch])."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["clipboard", "control"],
+      "description": "Message category. Clipboard messages contain clipboard payloads, control messages coordinate sessions."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Typed payload whose structure depends on the message type."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "clipboard" }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/clipboardPayload" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "control" }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/controlPayload" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "base64": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+      "description": "Base64-encoded data without newlines."
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "Lowercase hexadecimal SHA-256 digest."
+    },
+    "clipboardPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["content_type", "data", "device", "encryption"],
+      "properties": {
+        "content_type": {
+          "type": "string",
+          "enum": ["text", "link", "image", "file"],
+          "description": "Type of clipboard content being synchronized."
+        },
+        "data": {
+          "type": "string",
+          "description": "Encrypted clipboard payload. Plain UTF-8 string for text and link types, Base64 for binary types."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["size", "hash"],
+          "properties": {
+            "size": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Original payload size in bytes before encryption."
+            },
+            "hash": {
+              "$ref": "#/$defs/hash"
+            },
+            "encoding": {
+              "type": "string",
+              "description": "Character encoding for text payloads (defaults to UTF-8)."
+            },
+            "mime_type": {
+              "type": "string",
+              "description": "MIME type for image or file payloads."
+            },
+            "filename": {
+              "type": "string",
+              "description": "Original filename for file payloads, including extension."
+            },
+            "extension": {
+              "type": "string",
+              "description": "File extension for file payloads."
+            },
+            "width": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Image width in pixels."
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Image height in pixels."
+            },
+            "title": {
+              "type": "string",
+              "description": "Page title for link payloads."
+            },
+            "favicon": {
+              "$ref": "#/$defs/base64",
+              "description": "Base64-encoded favicon for link payloads."
+            }
+          }
+        },
+        "device": {
+          "$ref": "#/$defs/device"
+        },
+        "encryption": {
+          "$ref": "#/$defs/encryption"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "content_type": { "const": "text" }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "type": "string",
+                "maxLength": 102400,
+                "description": "UTF-8 encoded text up to 100KB."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "content_type": { "const": "link" }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "type": "string",
+                "format": "uri",
+                "maxLength": 2048,
+                "description": "URL conforming to RFC 3986."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "content_type": { "enum": ["image", "file"] }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "$ref": "#/$defs/base64",
+                "description": "Base64-encoded binary content." }
+            }
+          }
+        }
+      ]
+    },
+    "device": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "platform", "name", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable device identifier generated during pairing."
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["macos", "android", "ios", "windows", "linux"],
+          "description": "Source platform for the clipboard event."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable device name shown in UI."
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?$",
+          "description": "Application version running on the device."
+        }
+      }
+    },
+    "encryption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "nonce", "tag"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "const": "AES-256-GCM",
+          "description": "Encryption algorithm identifier."
+        },
+        "nonce": {
+          "$ref": "#/$defs/base64",
+          "description": "Base64-encoded 12-byte nonce."
+        },
+        "tag": {
+          "$ref": "#/$defs/base64",
+          "description": "Base64-encoded 16-byte authentication tag."
+        }
+      }
+    },
+    "controlPayload": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "handshake",
+            "handshake_ack",
+            "ping",
+            "pong",
+            "disconnect",
+            "error"
+          ],
+          "description": "Control command identifier."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "handshake" }
+            }
+          },
+          "then": {
+            "required": ["device", "auth"],
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "handshake" },
+              "device": { "$ref": "#/$defs/device" },
+              "auth": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["signature"],
+                "properties": {
+                  "signature": {
+                    "$ref": "#/$defs/base64",
+                    "description": "Signed challenge proving device identity."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "handshake_ack" }
+            }
+          },
+          "then": {
+            "required": ["session_id", "expires_at"],
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "handshake_ack" },
+              "session_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Opaque token referencing the active session."
+              },
+              "expires_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the session will expire."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "ping" }
+            }
+          },
+          "then": {
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "ping" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "pong" }
+            }
+          },
+          "then": {
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "pong" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "disconnect" }
+            }
+          },
+          "then": {
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "disconnect" },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "user_logout",
+                  "app_background",
+                  "network_change",
+                  "device_sleep"
+                ],
+                "description": "Reason for disconnecting."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "error" }
+            }
+          },
+          "then": {
+            "required": ["code", "message"],
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "error" },
+              "code": {
+                "type": "string",
+                "enum": [
+                  "INVALID_MESSAGE",
+                  "UNSUPPORTED_VERSION",
+                  "UNAUTHORIZED",
+                  "RATE_LIMITED",
+                  "PAYLOAD_TOO_LARGE",
+                  "DEVICE_NOT_PAIRED"
+                ],
+                "description": "Machine-readable error code."
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Human-readable error description."
+              },
+              "details": {
+                "type": "object",
+                "description": "Optional structured context describing the error.",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,9 +1,9 @@
 # Hypo Project Status
 
-**Last Updated**: October 1, 2025  
+**Last Updated**: October 2, 2025
 **Current Sprint**: Sprint 1 - Foundation & Architecture  
 **Project Phase**: Initialization  
-**Overall Progress**: 5%
+**Overall Progress**: 6%
 
 ---
 
@@ -18,6 +18,7 @@
 - [x] Initialize project structure (mono-repo layout)
 - [x] Created comprehensive README with project overview
 - [x] Defined protocol specification (docs/protocol.md)
+- [x] Published JSON Schema for protocol validation (docs/protocol.schema.json)
 - [x] Initialized backend Rust project structure
 - [x] Initialized Android project structure with Gradle
 - [x] Set up Git repository with initial commit
@@ -44,10 +45,10 @@ None currently
 | Phase 1.3: Security Foundation | Pending | 0% |
 
 **Next Steps**:
-1. Create mono-repo directory structure
-2. Initialize platform-specific projects (Xcode, Android Studio, Cargo)
-3. Define and document JSON message protocol
-4. Research and select cryptographic libraries
+1. Decide whether to adopt Protocol Buffers alongside JSON messaging
+2. Prototype schema validation in backend integration tests
+3. Begin evaluating cryptographic libraries across platforms
+4. Schedule kickoff for macOS project initialization
 
 ---
 
@@ -131,6 +132,9 @@ None currently
 - **Backend**: Initialized Rust project with Actix-web, Redis client, rate limiter
 - **Android**: Initialized project with Gradle, Compose, Hilt DI setup
 - **Infrastructure**: Set up Git repository, created 38 files totaling 4600+ lines
+
+### October 2, 2025
+- **Protocol**: Added formal JSON Schema definition for clipboard/control messages to support validation tooling
 
 ---
 

--- a/tasks/tasks.md
+++ b/tasks/tasks.md
@@ -25,7 +25,7 @@ Last Updated: October 1, 2025
   - [ ] Backend: Rust 1.75+, Redis local instance
 
 ### Phase 1.2: Protocol Definition
-- [ ] Define JSON message schema with validation
+- [x] Define JSON message schema with validation (see `docs/protocol.schema.json`)
 - [ ] Implement protocol buffers or stick with JSON (decision point)
 - [ ] Create protocol documentation with examples
 - [ ] Define error codes and handling


### PR DESCRIPTION
## Summary
- add a machine-readable JSON Schema for clipboard/control protocol messages and document how to validate against it
- mark the schema deliverable complete in the sprint tracker and update project status/changelog to reflect the new artifact

## Testing
- python -m json.tool docs/protocol.schema.json

------
https://chatgpt.com/codex/tasks/task_e_68dcf928620883258271fd91c4132071