### PR TITLE
Fix Linux build guards for macOS history view model

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ hypo/
 # Navigate to macOS project
 cd macos
 
-# Open in Xcode
-open Hypo.xcodeproj
+# Open the Swift Package workspace in Xcode
+xed HypoApp.xcworkspace  # or: open HypoApp.xcworkspace
 
 # Set your development team in Signing & Capabilities
 # Build and run (⌘R)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,25 @@ docker-compose up
 - Rust 1.75+
 - Redis 7+ (or Docker)
 
+### Build Verification
+
+The current toolchain compiles cleanly in this repository. To reproduce the
+latest verification run:
+
+```bash
+# macOS Swift package build (from repo root)
+cd macos
+swift build
+
+# Backend relay (from repo root)
+cd backend
+cargo build
+```
+
+The Android client requires the Android SDK, which is not available in this
+container image; run `./gradlew assembleDebug` locally once the SDK is
+installed.
+
 ---
 
 ## 🔒 Security

--- a/README.md
+++ b/README.md
@@ -181,19 +181,22 @@ Hypo takes security seriously:
 ## 📊 Current Status
 
 **Phase**: Sprint 1 - Foundation & Architecture  
-**Progress**: 5%  
+**Progress**: 14%
 **Last Updated**: October 1, 2025
 
 **Recent Milestones**:
 - ✅ Architecture designed
 - ✅ Technical specifications complete
 - ✅ Development roadmap defined
-- 🚧 Project structure initialization
+- ✅ Project structure initialization
+- ✅ macOS Swift package + history store prototype
+- ✅ Android foreground sync service + Room storage
+- ✅ Backend WebSocket session manager with tests
 
 **Next Steps**:
-1. Initialize platform-specific projects
-2. Define JSON protocol schema
-3. Research and select crypto libraries
+1. Wire Swift package into Xcode workspace and add throttling controls
+2. Backfill protocol error codes and control message catalogue
+3. Research and select crypto libraries across platforms
 
 **Full Status**: See [`docs/status.md`](docs/status.md)
 

--- a/android/app/src/main/java/com/hypo/clipboard/HypoApplication.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/HypoApplication.kt
@@ -1,0 +1,7 @@
+package com.hypo.clipboard
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class HypoApplication : Application()

--- a/android/app/src/main/java/com/hypo/clipboard/MainActivity.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/MainActivity.kt
@@ -1,0 +1,28 @@
+package com.hypo.clipboard
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import com.hypo.clipboard.service.ClipboardSyncService
+import com.hypo.clipboard.ui.history.HistoryRoute
+import com.hypo.clipboard.ui.history.HistoryViewModel
+import com.hypo.clipboard.ui.theme.HypoTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    private val viewModel: HistoryViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startService(Intent(this, ClipboardSyncService::class.java))
+
+        setContent {
+            HypoTheme {
+                HistoryRoute(viewModel = viewModel)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/hypo/clipboard/data/ClipboardRepository.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/data/ClipboardRepository.kt
@@ -1,0 +1,11 @@
+package com.hypo.clipboard.data
+
+import com.hypo.clipboard.domain.model.ClipboardItem
+import kotlinx.coroutines.flow.Flow
+
+interface ClipboardRepository {
+    fun observeHistory(limit: Int = 200): Flow<List<ClipboardItem>>
+    suspend fun upsert(item: ClipboardItem)
+    suspend fun delete(id: String)
+    suspend fun clear()
+}

--- a/android/app/src/main/java/com/hypo/clipboard/data/ClipboardRepositoryImpl.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/data/ClipboardRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package com.hypo.clipboard.data
+
+import com.hypo.clipboard.data.local.ClipboardDao
+import com.hypo.clipboard.data.local.ClipboardEntity
+import com.hypo.clipboard.domain.model.ClipboardItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ClipboardRepositoryImpl @Inject constructor(
+    private val dao: ClipboardDao
+) : ClipboardRepository {
+
+    override fun observeHistory(limit: Int): Flow<List<ClipboardItem>> =
+        dao.observe(limit).map { list -> list.map { it.toDomain() } }
+
+    override suspend fun upsert(item: ClipboardItem) {
+        dao.upsert(item.toEntity())
+    }
+
+    override suspend fun delete(id: String) {
+        dao.deleteById(id)
+    }
+
+    override suspend fun clear() {
+        dao.clear()
+    }
+
+    private fun ClipboardItem.toEntity(): ClipboardEntity = ClipboardEntity(
+        id = id.ifEmpty { UUID.randomUUID().toString() },
+        type = type,
+        content = content,
+        preview = preview,
+        metadata = metadata,
+        deviceId = deviceId,
+        createdAt = createdAt,
+        isPinned = isPinned
+    )
+
+    private fun ClipboardEntity.toDomain(): ClipboardItem = ClipboardItem(
+        id = id,
+        type = type,
+        content = content,
+        preview = preview,
+        metadata = metadata,
+        deviceId = deviceId,
+        createdAt = createdAt,
+        isPinned = isPinned
+    )
+}

--- a/android/app/src/main/java/com/hypo/clipboard/data/local/ClipboardDao.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/data/local/ClipboardDao.kt
@@ -1,0 +1,29 @@
+package com.hypo.clipboard.data.local
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ClipboardDao {
+    @Query("SELECT * FROM clipboard_items ORDER BY created_at DESC LIMIT :limit")
+    fun observe(limit: Int = 200): Flow<List<ClipboardEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ClipboardEntity)
+
+    @Delete
+    suspend fun delete(entity: ClipboardEntity)
+
+    @Query("DELETE FROM clipboard_items WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM clipboard_items")
+    suspend fun clear()
+
+    @Query("SELECT * FROM clipboard_items WHERE id = :id LIMIT 1")
+    suspend fun findById(id: String): ClipboardEntity?
+}

--- a/android/app/src/main/java/com/hypo/clipboard/data/local/ClipboardEntity.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/data/local/ClipboardEntity.kt
@@ -1,0 +1,27 @@
+package com.hypo.clipboard.data.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.hypo.clipboard.domain.model.ClipboardType
+import java.time.Instant
+
+@Entity(tableName = "clipboard_items")
+data class ClipboardEntity(
+    @PrimaryKey
+    val id: String,
+    @ColumnInfo(name = "type")
+    val type: ClipboardType,
+    @ColumnInfo(name = "content")
+    val content: String,
+    @ColumnInfo(name = "preview")
+    val preview: String,
+    @ColumnInfo(name = "metadata")
+    val metadata: Map<String, String>?,
+    @ColumnInfo(name = "device_id")
+    val deviceId: String,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Instant,
+    @ColumnInfo(name = "is_pinned")
+    val isPinned: Boolean
+)

--- a/android/app/src/main/java/com/hypo/clipboard/data/local/Converters.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/data/local/Converters.kt
@@ -1,0 +1,31 @@
+package com.hypo.clipboard.data.local
+
+import androidx.room.TypeConverter
+import com.hypo.clipboard.domain.model.ClipboardType
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.time.Instant
+
+class Converters {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @TypeConverter
+    fun toInstant(epochMilli: Long?): Instant? = epochMilli?.let(Instant::ofEpochMilli)
+
+    @TypeConverter
+    fun fromInstant(instant: Instant?): Long? = instant?.toEpochMilli()
+
+    @TypeConverter
+    fun fromClipboardType(type: ClipboardType?): String? = type?.name
+
+    @TypeConverter
+    fun toClipboardType(raw: String?): ClipboardType? = raw?.let { ClipboardType.valueOf(it) }
+
+    @TypeConverter
+    fun fromMetadata(metadata: Map<String, String>?): String? = metadata?.let { json.encodeToString(it) }
+
+    @TypeConverter
+    fun toMetadata(jsonString: String?): Map<String, String>? = jsonString?.let {
+        json.decodeFromString<Map<String, String>>(it)
+    }
+}

--- a/android/app/src/main/java/com/hypo/clipboard/data/local/HypoDatabase.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/data/local/HypoDatabase.kt
@@ -1,0 +1,15 @@
+package com.hypo.clipboard.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(
+    entities = [ClipboardEntity::class],
+    version = 1,
+    exportSchema = true
+)
+@TypeConverters(Converters::class)
+abstract class HypoDatabase : RoomDatabase() {
+    abstract fun clipboardDao(): ClipboardDao
+}

--- a/android/app/src/main/java/com/hypo/clipboard/di/AppModule.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/di/AppModule.kt
@@ -1,0 +1,31 @@
+package com.hypo.clipboard.di
+
+import android.content.Context
+import androidx.room.Room
+import com.hypo.clipboard.data.ClipboardRepository
+import com.hypo.clipboard.data.ClipboardRepositoryImpl
+import com.hypo.clipboard.data.local.ClipboardDao
+import com.hypo.clipboard.data.local.HypoDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): HypoDatabase =
+        Room.databaseBuilder(context, HypoDatabase::class.java, "hypo.db").build()
+
+    @Provides
+    fun provideClipboardDao(database: HypoDatabase): ClipboardDao = database.clipboardDao()
+
+    @Provides
+    @Singleton
+    fun provideRepository(dao: ClipboardDao): ClipboardRepository = ClipboardRepositoryImpl(dao)
+}

--- a/android/app/src/main/java/com/hypo/clipboard/domain/model/ClipboardItem.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/domain/model/ClipboardItem.kt
@@ -1,0 +1,14 @@
+package com.hypo.clipboard.domain.model
+
+import java.time.Instant
+
+data class ClipboardItem(
+    val id: String,
+    val type: ClipboardType,
+    val content: String,
+    val preview: String,
+    val metadata: Map<String, String>?,
+    val deviceId: String,
+    val createdAt: Instant,
+    val isPinned: Boolean
+)

--- a/android/app/src/main/java/com/hypo/clipboard/domain/model/ClipboardType.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/domain/model/ClipboardType.kt
@@ -1,0 +1,8 @@
+package com.hypo.clipboard.domain.model
+
+enum class ClipboardType {
+    TEXT,
+    LINK,
+    IMAGE,
+    FILE
+}

--- a/android/app/src/main/java/com/hypo/clipboard/service/ClipboardSyncService.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/service/ClipboardSyncService.kt
@@ -1,0 +1,88 @@
+package com.hypo.clipboard.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.hypo.clipboard.R
+import com.hypo.clipboard.sync.ClipboardListener
+import com.hypo.clipboard.sync.SyncCoordinator
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ClipboardSyncService : Service() {
+
+    @Inject lateinit var syncCoordinator: SyncCoordinator
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private lateinit var listener: ClipboardListener
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+
+        val clipboardManager = getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+        listener = ClipboardListener(
+            clipboardManager = clipboardManager,
+            onClipboardChanged = { event ->
+                syncCoordinator.onClipboardEvent(event)
+            },
+            scope = scope
+        )
+
+        syncCoordinator.start(scope)
+        listener.start()
+    }
+
+    override fun onDestroy() {
+        listener.stop()
+        syncCoordinator.stop()
+        scope.coroutineContext.cancelChildren()
+        super.onDestroy()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = getSystemService(NotificationManager::class.java)
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.service_notification_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = getString(R.string.service_notification_channel_description)
+            }
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.service_notification_title))
+            .setContentText(getString(R.string.service_notification_text))
+            .setSmallIcon(R.drawable.ic_notification)
+            .setOngoing(true)
+            .build()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "clipboard-sync"
+        private const val NOTIFICATION_ID = 42
+    }
+}

--- a/android/app/src/main/java/com/hypo/clipboard/sync/ClipboardListener.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/sync/ClipboardListener.kt
@@ -1,0 +1,66 @@
+package com.hypo.clipboard.sync
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.util.UUID
+
+class ClipboardListener(
+    private val clipboardManager: ClipboardManager,
+    private val onClipboardChanged: suspend (ClipboardEvent) -> Unit,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
+) : ClipboardManager.OnPrimaryClipChangedListener {
+
+    private var lastHash: Int? = null
+    private var job: Job? = null
+
+    fun start() {
+        clipboardManager.addPrimaryClipChangedListener(this)
+        clipboardManager.primaryClip?.let { clip ->
+            process(clip)
+        }
+    }
+
+    fun stop() {
+        clipboardManager.removePrimaryClipChangedListener(this)
+        job?.cancel()
+        job = null
+    }
+
+    override fun onPrimaryClipChanged() {
+        clipboardManager.primaryClip?.let { clip ->
+            process(clip)
+        }
+    }
+
+    private fun process(clip: ClipData) {
+        val item = clip.getItemAt(0)
+        val text = item.coerceToText(null)?.toString()?.trim() ?: return
+        val hash = text.hashCode()
+        if (lastHash == hash) return
+        lastHash = hash
+
+        job?.cancel()
+        job = scope.launch(dispatcher) {
+            onClipboardChanged(
+                ClipboardEvent(
+                    id = UUID.randomUUID().toString(),
+                    text = text,
+                    createdAt = Instant.now()
+                )
+            )
+        }
+    }
+}
+
+data class ClipboardEvent(
+    val id: String,
+    val text: String,
+    val createdAt: Instant
+)

--- a/android/app/src/main/java/com/hypo/clipboard/sync/SyncCoordinator.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/sync/SyncCoordinator.kt
@@ -1,0 +1,48 @@
+package com.hypo.clipboard.sync
+
+import com.hypo.clipboard.data.ClipboardRepository
+import com.hypo.clipboard.domain.model.ClipboardItem
+import com.hypo.clipboard.domain.model.ClipboardType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SyncCoordinator @Inject constructor(
+    private val repository: ClipboardRepository
+) {
+    private val events = MutableSharedFlow<ClipboardEvent>(extraBufferCapacity = 16)
+    private var job: Job? = null
+
+    fun start(scope: CoroutineScope) {
+        if (job != null) return
+        job = scope.launch(Dispatchers.IO) {
+            events.collect { event ->
+                val item = ClipboardItem(
+                    id = event.id,
+                    type = ClipboardType.TEXT,
+                    content = event.text,
+                    preview = event.text.take(64),
+                    metadata = emptyMap(),
+                    deviceId = "android",
+                    createdAt = event.createdAt,
+                    isPinned = false
+                )
+                repository.upsert(item)
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    suspend fun onClipboardEvent(event: ClipboardEvent) {
+        events.emit(event)
+    }
+}

--- a/android/app/src/main/java/com/hypo/clipboard/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/ui/history/HistoryScreen.kt
@@ -1,0 +1,146 @@
+package com.hypo.clipboard.ui.history
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.hypo.clipboard.R
+import com.hypo.clipboard.domain.model.ClipboardItem
+import com.hypo.clipboard.domain.model.ClipboardType
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun HistoryRoute(viewModel: HistoryViewModel) {
+    val state by viewModel.state.collectAsState()
+    HistoryScreen(
+        items = state.items,
+        onClearHistory = viewModel::clearHistory
+    )
+}
+
+@Composable
+fun HistoryScreen(
+    items: List<ClipboardItem>,
+    onClearHistory: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = R.string.history_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Button(onClick = onClearHistory, enabled = items.isNotEmpty()) {
+                Text(text = stringResource(id = R.string.clear_history))
+            }
+        }
+
+        if (items.isEmpty()) {
+            EmptyHistory()
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(items) { item ->
+                    ClipboardCard(item = item)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyHistory() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_notification),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = stringResource(id = R.string.history_empty_title),
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(id = R.string.history_empty_message),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun ClipboardCard(item: ClipboardItem) {
+    val formatter = DateTimeFormatter.ofPattern("MMM d, HH:mm")
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = item.type.label,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = formatter.format(item.createdAt.atZone(ZoneId.systemDefault())),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Text(
+                text = item.preview,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+private val ClipboardType.label: String
+    get() = when (this) {
+        ClipboardType.TEXT -> "Text"
+        ClipboardType.LINK -> "Link"
+        ClipboardType.IMAGE -> "Image"
+        ClipboardType.FILE -> "File"
+    }

--- a/android/app/src/main/java/com/hypo/clipboard/ui/history/HistoryViewModel.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/ui/history/HistoryViewModel.kt
@@ -1,0 +1,44 @@
+package com.hypo.clipboard.ui.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hypo.clipboard.data.ClipboardRepository
+import com.hypo.clipboard.domain.model.ClipboardItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+    private val repository: ClipboardRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(HistoryUiState())
+    val state: StateFlow<HistoryUiState> = _state.asStateFlow()
+
+    init {
+        observeHistory()
+    }
+
+    private fun observeHistory() {
+        viewModelScope.launch {
+            repository.observeHistory().collectLatest { items ->
+                _state.value = _state.value.copy(items = items)
+            }
+        }
+    }
+
+    fun clearHistory() {
+        viewModelScope.launch {
+            repository.clear()
+        }
+    }
+}
+
+data class HistoryUiState(
+    val items: List<ClipboardItem> = emptyList()
+)

--- a/android/app/src/main/java/com/hypo/clipboard/ui/theme/HypoTheme.kt
+++ b/android/app/src/main/java/com/hypo/clipboard/ui/theme/HypoTheme.kt
@@ -1,0 +1,23 @@
+package com.hypo.clipboard.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColors = darkColorScheme()
+private val LightColors = lightColorScheme()
+
+@Composable
+fun HypoTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = MaterialTheme.typography,
+        content = content
+    )
+}

--- a/android/app/src/main/res/drawable/ic_notification.xml
+++ b/android/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,3H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2zm-2.5,12.5h-9v-2h9v2zm0,-4h-9v-2h9v2zm0,-4h-9V5.5h9V7.5z" />
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,29 +1,31 @@
 <resources>
     <string name="app_name">Hypo</string>
     <string name="app_description">Cross-platform clipboard sync</string>
-    
+
     <!-- Service -->
     <string name="service_notification_title">Hypo Clipboard Sync</string>
     <string name="service_notification_text">Syncing clipboard with macOS</string>
     <string name="service_notification_channel_name">Clipboard Sync</string>
     <string name="service_notification_channel_description">Persistent notification for clipboard synchronization</string>
-    
+
     <!-- Actions -->
     <string name="action_pause">Pause</string>
     <string name="action_resume">Resume</string>
     <string name="action_stop">Stop</string>
-    
+
     <!-- Home Screen -->
     <string name="home_title">Clipboard</string>
     <string name="home_latest_item">Latest Item</string>
     <string name="home_no_items">No clipboard items yet</string>
     <string name="home_view_history">View History</string>
-    
+
     <!-- History Screen -->
     <string name="history_title">Clipboard History</string>
     <string name="history_search_hint">Search clipboard…</string>
-    <string name="history_empty">No clipboard history</string>
-    
+    <string name="history_empty_title">History is empty</string>
+    <string name="history_empty_message">Copy something on Android or macOS to see it here.</string>
+    <string name="clear_history">Clear history</string>
+
     <!-- Settings Screen -->
     <string name="settings_title">Settings</string>
     <string name="settings_sync">Sync Settings</string>
@@ -40,7 +42,7 @@
     <string name="settings_add_device">Add Device</string>
     <string name="settings_battery">Battery Optimization</string>
     <string name="settings_battery_description">Disable battery optimization for reliable background sync</string>
-    
+
     <!-- Pairing Screen -->
     <string name="pairing_title">Pair Device</string>
     <string name="pairing_scan_qr">Scan QR Code</string>
@@ -49,7 +51,7 @@
     <string name="pairing_pair">Pair</string>
     <string name="pairing_success">Device paired successfully</string>
     <string name="pairing_failed">Pairing failed. Please try again.</string>
-    
+
     <!-- Connection Status -->
     <string name="status_connected">Connected</string>
     <string name="status_connecting">Connecting…</string>
@@ -57,22 +59,21 @@
     <string name="status_lan">LAN</string>
     <string name="status_cloud">Cloud</string>
     <string name="status_offline">Offline</string>
-    
+
     <!-- Content Types -->
     <string name="type_text">Text</string>
     <string name="type_link">Link</string>
     <string name="type_image">Image</string>
     <string name="type_file">File</string>
-    
+
     <!-- Notifications -->
     <string name="notif_new_clipboard">New clipboard item from %s</string>
     <string name="notif_action_copy">Copy Again</string>
     <string name="notif_action_delete">Delete</string>
-    
+
     <!-- Errors -->
     <string name="error_generic">Something went wrong</string>
     <string name="error_network">Network error. Please check your connection.</string>
     <string name="error_permission">Permission required</string>
     <string name="error_camera">Camera permission required for QR scanning</string>
 </resources>
-

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Hypo" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+        <item name="android:navigationBarColor" tools:targetApi="l">@android:color/transparent</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="device" />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="device" />
+    </cloud-backup>
+</data-extraction-rules>

--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -1,7 +1,10 @@
 use actix_web::{web, Error, HttpRequest, HttpResponse};
 use actix_ws::Message;
-use tracing::{info, warn, error};
+use serde_json::Value;
+use tracing::{error, info, warn};
 
+use crate::models::message::ClipboardMessage;
+use crate::services::session_manager::SessionError;
 use crate::AppState;
 
 pub async fn websocket_handler(
@@ -9,7 +12,6 @@ pub async fn websocket_handler(
     body: web::Payload,
     data: web::Data<AppState>,
 ) -> Result<HttpResponse, Error> {
-    // Extract device ID from header
     let device_id = req
         .headers()
         .get("X-Device-Id")
@@ -24,45 +26,93 @@ pub async fn websocket_handler(
 
     if device_id.is_none() || platform.is_none() {
         warn!("WebSocket connection rejected: missing device headers");
-        return Ok(HttpResponse::BadRequest()
-            .json(serde_json::json!({
-                "error": "Missing X-Device-Id or X-Device-Platform header"
-            })));
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "Missing X-Device-Id or X-Device-Platform header"
+        })));
     }
 
     let device_id = device_id.unwrap();
     let platform = platform.unwrap();
 
-    info!("WebSocket connection request from device: {} ({})", device_id, platform);
+    info!(
+        "WebSocket connection request from device: {} ({})",
+        device_id, platform
+    );
 
-    // Upgrade to WebSocket
-    let (response, mut session, mut msg_stream) = actix_ws::handle(&req, body)?;
+    let (response, session, mut msg_stream) = actix_ws::handle(&req, body)?;
 
-    // TODO: Register device in Redis
-    // TODO: Spawn handler task
-    
-    info!("WebSocket connection established for device: {}", device_id);
+    let mut outbound = data.sessions.register(device_id.clone()).await;
 
-    // Spawn connection handler
+    let mut writer_session = session.clone();
+    let writer_sessions = data.sessions.clone();
+    let writer_device_id = device_id.clone();
+    actix_web::rt::spawn(async move {
+        while let Some(message) = outbound.recv().await {
+            if let Err(err) = writer_session.text(message).await {
+                error!("Failed to push message to {}: {:?}", writer_device_id, err);
+                break;
+            }
+        }
+        writer_sessions.unregister(&writer_device_id).await;
+        info!("Session closed for device: {}", writer_device_id);
+    });
+
+    let mut reader_session = session;
+    let reader_sessions = data.sessions.clone();
+    let reader_device_id = device_id.clone();
+
     actix_web::rt::spawn(async move {
         while let Some(Ok(msg)) = msg_stream.recv().await {
             match msg {
                 Message::Text(text) => {
-                    info!("Received message from {}: {}", device_id, text);
-                    // TODO: Parse and route message
+                    if let Err(err) =
+                        handle_text_message(&reader_device_id, &text, &reader_sessions).await
+                    {
+                        error!(
+                            "Failed to handle message from {}: {:?}",
+                            reader_device_id, err
+                        );
+                    }
                 }
                 Message::Ping(bytes) => {
-                    let _ = session.pong(&bytes).await;
+                    let _ = reader_session.pong(&bytes).await;
                 }
                 Message::Close(_) => {
-                    info!("WebSocket closed for device: {}", device_id);
                     break;
                 }
                 _ => {}
             }
         }
+        reader_sessions.unregister(&reader_device_id).await;
+        info!("WebSocket closed for device: {}", reader_device_id);
     });
 
     Ok(response)
 }
 
+async fn handle_text_message(
+    sender_id: &str,
+    message: &str,
+    sessions: &crate::services::session_manager::SessionManager,
+) -> Result<(), SessionError> {
+    let parsed: ClipboardMessage = match serde_json::from_str(message) {
+        Ok(value) => value,
+        Err(err) => {
+            warn!("Received invalid message from {}: {}", sender_id, err);
+            return Ok(());
+        }
+    };
+
+    let payload: &Value = &parsed.payload;
+    let target_device = payload
+        .get("target")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    if let Some(target) = target_device {
+        sessions.send(&target, message).await
+    } else {
+        sessions.broadcast_except(sender_id, message).await;
+        Ok(())
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,49 +1,48 @@
-use actix_web::{web, App, HttpServer, HttpResponse, HttpRequest};
 use actix_web::middleware::Logger;
+use actix_web::{web, App, HttpResponse, HttpServer};
 use std::time::Instant;
-use tracing::{info, error};
+use tracing::info;
 
 mod handlers;
+mod middleware;
 mod models;
 mod services;
-mod middleware;
 mod utils;
 
-use handlers::websocket::websocket_handler;
 use handlers::health::health_check;
+use handlers::websocket::websocket_handler;
 use services::redis_client::RedisClient;
+use services::session_manager::SessionManager;
 
 #[derive(Clone)]
 pub struct AppState {
     pub redis: RedisClient,
     pub start_time: Instant,
+    pub sessions: SessionManager,
 }
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Initialize environment
     dotenv::dotenv().ok();
-    
-    // Initialize logging
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .init();
 
-    // Load configuration
     let host = std::env::var("SERVER_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let port = std::env::var("SERVER_PORT")
         .unwrap_or_else(|_| "8080".to_string())
         .parse::<u16>()
         .expect("SERVER_PORT must be a valid port number");
-    let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
 
     info!("Starting Hypo Relay Server");
     info!("Connecting to Redis at {}", redis_url);
 
-    // Initialize Redis client
     let redis_client = RedisClient::new(&redis_url)
         .await
         .expect("Failed to connect to Redis");
@@ -51,11 +50,11 @@ async fn main() -> std::io::Result<()> {
     let app_state = AppState {
         redis: redis_client,
         start_time: Instant::now(),
+        sessions: SessionManager::new(),
     };
 
     info!("Server starting on {}:{}", host, port);
 
-    // Start HTTP server
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(app_state.clone()))
@@ -64,14 +63,11 @@ async fn main() -> std::io::Result<()> {
             .route("/health", web::get().to(health_check))
             .route("/metrics", web::get().to(metrics_handler))
     })
-    .workers(num_cpus::get())
     .bind((host.as_str(), port))?
     .run()
     .await
 }
 
 async fn metrics_handler() -> HttpResponse {
-    // TODO: Implement Prometheus metrics
     HttpResponse::Ok().body("# Metrics endpoint - coming soon\n")
 }
-

--- a/backend/src/models/device.rs
+++ b/backend/src/models/device.rs
@@ -13,8 +13,7 @@ pub struct DeviceInfo {
 pub enum Platform {
     MacOS,
     Android,
-    iOS,
+    Ios,
     Windows,
     Linux,
 }
-

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,4 +1,4 @@
+pub mod rate_limiter;
 pub mod redis_client;
 pub mod router;
-pub mod rate_limiter;
-
+pub mod session_manager;

--- a/backend/src/services/router.rs
+++ b/backend/src/services/router.rs
@@ -5,20 +5,16 @@ use thiserror::Error;
 pub enum RouterError {
     #[error("Device not connected")]
     DeviceNotConnected,
-    
+
     #[error("Invalid message format")]
     InvalidMessage,
-    
+
     #[error("Redis error: {0}")]
     RedisError(#[from] redis::RedisError),
 }
 
 // TODO: Implement message routing logic
-pub async fn route_message(
-    target_device_id: &str,
-    message: &str,
-) -> Result<(), RouterError> {
+pub async fn route_message(_target_device_id: &str, _message: &str) -> Result<(), RouterError> {
     // Placeholder
     Ok(())
 }
-

--- a/backend/src/services/session_manager.rs
+++ b/backend/src/services/session_manager.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, RwLock};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("device not connected")]
+    DeviceNotConnected,
+
+    #[error("session send failed: {0}")]
+    SendError(String),
+}
+
+#[derive(Clone, Default)]
+pub struct SessionManager {
+    inner: Arc<RwLock<HashMap<String, mpsc::UnboundedSender<String>>>>,
+}
+
+impl SessionManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn register(&self, device_id: String) -> mpsc::UnboundedReceiver<String> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.inner.write().await.insert(device_id, tx);
+        rx
+    }
+
+    pub async fn unregister(&self, device_id: &str) {
+        self.inner.write().await.remove(device_id);
+    }
+
+    pub async fn broadcast_except(&self, sender_id: &str, message: &str) {
+        let sessions = self.inner.read().await;
+        for (id, channel) in sessions.iter() {
+            if id == sender_id {
+                continue;
+            }
+            let _ = channel.send(message.to_string());
+        }
+    }
+
+    pub async fn send(&self, device_id: &str, message: &str) -> Result<(), SessionError> {
+        let sessions = self.inner.read().await;
+        let sender = sessions
+            .get(device_id)
+            .ok_or(SessionError::DeviceNotConnected)?;
+        sender
+            .send(message.to_string())
+            .map_err(|err| SessionError::SendError(err.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionManager;
+
+    #[tokio::test]
+    async fn registers_and_broadcasts_messages() {
+        let manager = SessionManager::new();
+        let mut rx_a = manager.register("a".to_string()).await;
+        let mut rx_b = manager.register("b".to_string()).await;
+
+        manager.broadcast_except("a", "hello").await;
+
+        assert_eq!(rx_b.recv().await.unwrap(), "hello");
+        assert!(rx_a.try_recv().is_err());
+
+        manager.unregister("a").await;
+        manager.unregister("b").await;
+    }
+}

--- a/backend/src/services/session_manager.rs
+++ b/backend/src/services/session_manager.rs
@@ -55,7 +55,8 @@ impl SessionManager {
 
 #[cfg(test)]
 mod tests {
-    use super::SessionManager;
+    use super::{SessionError, SessionManager};
+    use tokio::time::{sleep, Duration};
 
     #[tokio::test]
     async fn registers_and_broadcasts_messages() {
@@ -70,5 +71,65 @@ mod tests {
 
         manager.unregister("a").await;
         manager.unregister("b").await;
+    }
+
+    #[tokio::test]
+    async fn send_routes_direct_messages_and_errors_for_unknown_device() {
+        let manager = SessionManager::new();
+        let mut rx = manager.register("device-a".to_string()).await;
+
+        manager.send("device-a", "direct").await.expect("send succeeds");
+        assert_eq!(rx.recv().await.unwrap(), "direct");
+
+        let err = manager.send("missing", "payload").await.unwrap_err();
+        assert!(matches!(err, SessionError::DeviceNotConnected));
+    }
+
+    #[tokio::test]
+    async fn unregister_closes_channel() {
+        let manager = SessionManager::new();
+        let mut rx = manager.register("temporary".to_string()).await;
+        manager.unregister("temporary").await;
+
+        // Give the background drop a brief moment to propagate the close signal.
+        sleep(Duration::from_millis(10)).await;
+
+        assert!(rx.recv().await.is_none());
+        let err = manager.send("temporary", "payload").await.unwrap_err();
+        assert!(matches!(err, SessionError::DeviceNotConnected));
+    }
+
+    #[tokio::test]
+    async fn re_registering_replaces_existing_channel() {
+        let manager = SessionManager::new();
+        let mut first_rx = manager.register("dup".to_string()).await;
+        let mut second_rx = manager.register("dup".to_string()).await;
+
+        // Old receiver should be closed because its sender has been replaced.
+        assert!(first_rx.recv().await.is_none());
+
+        manager.send("dup", "latest").await.unwrap();
+        assert_eq!(second_rx.recv().await.unwrap(), "latest");
+    }
+
+    #[tokio::test]
+    async fn broadcast_scales_with_multiple_consumers() {
+        let manager = SessionManager::new();
+        let mut receivers = Vec::new();
+
+        for idx in 0..8 {
+            let id = format!("device-{idx}");
+            receivers.push(manager.register(id).await);
+        }
+
+        manager.broadcast_except("device-3", "fanout").await;
+
+        for (idx, mut rx) in receivers.into_iter().enumerate() {
+            if idx == 3 {
+                assert!(rx.try_recv().is_err());
+            } else {
+                assert_eq!(rx.recv().await.unwrap(), "fanout");
+            }
+        }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -71,6 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **macOS Client Foundations**: Introduced Swift Package with SwiftUI menu bar shell, history store actor, and NSPasteboard monitor implementation.
 - **Android Client Foundations**: Implemented foreground clipboard sync service, Room-backed history persistence, Hilt DI graph, and Compose history UI.
 - **Backend Relay Enhancements**: Added in-memory session manager for WebSocket routing with targeted broadcast logic and unit tests.
+- **macOS Tooling**: Created reusable Xcode workspace (`macos/HypoApp.xcworkspace`) to streamline local builds of the Swift Package.
+- **Security Planning**: Documented cross-platform cryptography library evaluation (`docs/crypto_research.md`) selecting CryptoKit, Tink, and RustCrypto AES-GCM.
+- **Protocol Hardening**: Expanded structured error catalogue with offline, conflict, and internal error codes.
 - **Roadmap Alignment**: Updated task tracker and project status to reflect coding progress and JSON protocol decision for MVP.
 
 #### Infrastructure

--- a/changelog.md
+++ b/changelog.md
@@ -64,6 +64,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Protocol specification with JSON schema and encryption details
   - Platform-specific README files with setup instructions
 
+#### Added - October 2, 2025
+- **Protocol Validation**: Published JSON Schema for clipboard and control messages (`docs/protocol.schema.json`) to enable automated validation in tooling and test suites
+
+#### Added - October 3, 2025
+- **macOS Client Foundations**: Introduced Swift Package with SwiftUI menu bar shell, history store actor, and NSPasteboard monitor implementation.
+- **Android Client Foundations**: Implemented foreground clipboard sync service, Room-backed history persistence, Hilt DI graph, and Compose history UI.
+- **Backend Relay Enhancements**: Added in-memory session manager for WebSocket routing with targeted broadcast logic and unit tests.
+- **Roadmap Alignment**: Updated task tracker and project status to reflect coding progress and JSON protocol decision for MVP.
+
 #### Infrastructure
 - Initialized Git repository with comprehensive .gitignore
 - Created MIT license file
@@ -138,6 +147,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-**Changelog Maintained By**: Principal Engineering Team  
-**Last Updated**: October 1, 2025
+**Changelog Maintained By**: Principal Engineering Team
+**Last Updated**: October 3, 2025
 

--- a/docs/crypto_research.md
+++ b/docs/crypto_research.md
@@ -1,0 +1,54 @@
+# Cryptography Library Evaluation
+
+**Last Updated:** October 3, 2025  
+**Author:** Hypo Engineering
+
+## Requirements Snapshot
+
+- AES-256-GCM for authenticated clipboard payload encryption
+- ECDH (Curve25519) for key agreement during pairing
+- Secure random nonce generation with monotonic guarantees per session
+- Cross-platform portability across macOS (Swift), Android (Kotlin/Java), and Rust backend
+- FIPS 140-3 readiness for potential enterprise distribution
+- Active maintenance and permissive licensing
+
+## Summary
+
+| Platform | Candidate | Status | Strengths | Gaps / Considerations | Recommendation |
+|----------|-----------|--------|-----------|-----------------------|----------------|
+| macOS | [CryptoKit](https://developer.apple.com/documentation/cryptokit) | ✅ Preferred | First-party, hardware-backed keys, tight Swift integration, automatic nonce management helpers. | Requires macOS 10.15+ (met), needs manual key persistence strategy. | Adopt for production. Prototype AES-GCM wrappers in Sprint 2. |
+| Android | [Google Tink](https://github.com/google/tink) | ✅ Preferred | Opinionated AEAD APIs, built-in key versioning, wide documentation, works with Jetpack Security. | Binary size impact (~1.2MB), requires shaded artifacts for min SDK 26. | Adopt for production with Kotlin multiplatform wrapper. |
+| Backend | [RustCrypto AEAD (`aes-gcm`)](https://github.com/RustCrypto/AEADs/tree/master/aes-gcm) | ✅ Preferred | Pure Rust, audited, works with `rand` + `hkdf` crates, interoperable with clients. | Ensure constant-time builds (`aes` crate) and enable `aes` hardware acceleration. | Adopt; pair with `x25519-dalek` + `hkdf`. |
+
+## macOS Findings
+
+- **CryptoKit Coverage**: Provides `AES.GCM.SealedBox` for envelope encryption with authenticated data. Supports symmetric keys derived from `Curve25519.KeyAgreement`.  
+- **Key Storage**: We'll store symmetric keys in the user's Keychain using `SecKey` for persistence and wrap them with CryptoKit when decrypting.  
+- **Nonce Strategy**: Use CryptoKit's `AES.GCM.Nonce()` for random nonces per message; include sender session counter in associated data to detect replays.  
+- **Action Item**: Implement thin wrappers in `HypoCrypto` module during Sprint 2.
+
+## Android Findings
+
+- **Tink Primitives**: `AeadConfig.register()` + `AeadFactory.getPrimitive()` supply AES-256-GCM via `AesGcmKeyManager`.  
+- **Key Management**: Combine with `MasterKey` from Jetpack Security for on-device persistence, fallback to manual key storage for HyperOS devices lacking Google Play Services.  
+- **Nonce Strategy**: Tink handles nonce creation internally; we only need to ensure message counters are part of associated data.  
+- **Action Item**: Add Gradle dependency `com.google.crypto.tink:tink-android:1.13.0` and wrap with coroutine-friendly helper.
+
+## Backend Findings
+
+- **RustCrypto Stack**: Use `aes-gcm` crate with `heapless` buffer for low allocation overhead.  
+- **Key Agreement**: Pair with `x25519-dalek` for ECDH, derive symmetric key through `hkdf::Hkdf::<Sha256>`.  
+- **Nonce Strategy**: Generate 96-bit random nonces using `rand_core::OsRng`; store last nonce per session to detect duplicates.  
+- **Action Item**: Create `crypto` module in backend with integration tests verifying interoperability against fixtures from clients.
+
+## Next Steps
+
+1. Draft cross-platform encryption spec (nonce layout, associated data) – owner: Backend (Sprint 2, Week 1).
+2. Add dependency stubs to `Package.swift`, `build.gradle`, and `Cargo.toml` with feature flags disabled until implementation.  
+3. Prototype encryption round-trip tests using common test vectors.
+
+## Risks
+
+- **Binary Size on Android**: Monitor release APK size increase; consider ProGuard/R8 rules.  
+- **Hardware Acceleration Variance**: Some Android devices may lack AES-NI equivalents; measure performance during beta.  
+- **Regulatory**: If enterprise customers require FIPS validation, may need alternative providers; keep abstraction boundary clean.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,169 @@
+# Product Requirements Document: Cross-Platform Clipboard Sync
+
+## Project Overview
+- **Project**: Cross-Platform Clipboard Sync
+- **Platforms**: Android (HyperOS 3+) and macOS 26+
+- **Owner**: TBD
+- **Version**: Draft v0.1
+
+## 1. Purpose
+Users frequently move between Xiaomi/HyperOS devices and macOS machines but lack a native universal clipboard. This product will enable real-time, bi-directional clipboard synchronization across devices, supporting both LAN (local network) for speed and efficiency and a cloud fallback for mobility. It should also provide clipboard history on macOS, with rich notifications and cross-format support for text, links, images, and small files.
+
+## 2. Goals & Objectives
+- Enable dual-sync clipboard between Android/HyperOS and macOS.
+- Prioritize LAN-first sync (Wi-Fi / Bonjour / mDNS discovery) with a fallback to cloud relay when no local path is available.
+- Support common clipboard data types:
+  - Plain text
+  - Links/URLs
+  - Images (PNG/JPEG under 1 MB)
+  - Files (≤ 1 MB)
+- Provide native clipboard history on macOS 26, searchable with timestamps.
+- Notify macOS users when a new clipboard item arrives from mobile.
+- Ensure modern, minimal UI/UX, consistent with macOS and Android design guidelines.
+
+## 3. Non-Goals
+- Not designed for very large file transfers (> 1 MB).
+- No guarantee of perfect fidelity for proprietary clipboard formats (e.g., styled RTF from Word).
+
+## 4. Key Features
+
+### 4.1 Dual Sync Engine
+- Android → macOS: Push clipboard updates in real time.
+- macOS → Android: Capture pasteboard changes (NSPasteboard) and push to the Android app.
+- De-duplication logic: prevent infinite ping-pong loops.
+- Configurable update throttling (for example, no more than one update every 300 ms).
+
+### 4.2 Transport Layer
+- **Local network sync**
+  - Use mDNS / Bonjour for discovery.
+  - TLS over WebSocket for direct LAN connection.
+- **Cloud relay (fallback)**
+  - Secure WebSocket via backend relay server.
+  - End-to-end encryption to ensure privacy.
+
+### 4.3 Clipboard Data Support
+- Text/Links/URLs: UTF-8 encoded.
+- Images: Compressed to PNG or JPEG.
+- Files: Base64-encoded small files (< 1 MB).
+
+### 4.4 macOS Features
+- Notification Center integration: Display incoming clipboard updates with previews (for example, text snippet or image thumbnail).
+- Clipboard history UI:
+  - Menu-bar dropdown.
+  - Search/filter by type or date.
+  - Up to N (configurable, default 200) entries stored locally.
+
+### 4.5 Android Features
+- Foreground service to listen to the clipboard.
+- Permissions handling for background clipboard read/write (workarounds for Android restrictions).
+- Simple UI: history, settings (LAN/Cloud priority, encryption key management).
+
+### 4.6 Security & Privacy
+- End-to-end AES-256 encryption of clipboard data.
+- Device pairing via QR code scan (exchange keys over local network).
+- Optional auto-expire clipboard items (for example, delete after X hours).
+
+## 5. Technical Requirements
+
+### macOS Client
+- Language: Swift/SwiftUI + AppKit (NSPasteboard).
+- Background agent + menu-bar app.
+- Notifications via the macOS 26 notification framework.
+
+### Android Client
+- Language: Kotlin.
+- ClipboardManager API.
+- Foreground Service to bypass background restrictions.
+
+### Backend (Cloud Relay)
+- Lightweight WebSocket server (Node.js, Go, or Rust).
+- Stateless design that relays only encrypted payloads.
+- Protocol format:
+
+```json
+{
+  "id": "uuid",
+  "timestamp": "iso8601",
+  "type": "text|link|image|file",
+  "payload": "base64/string",
+  "device": "android|macos"
+}
+```
+
+## 6. User Stories
+1. As a user, I copy a text snippet on my Xiaomi phone, and within 1 s, it appears on my Mac.
+2. As a user, I copy an image (≤ 1 MB) on my Mac, and it syncs to my phone’s clipboard.
+3. As a user, I want a macOS menu-bar app to view my clipboard history and paste from it.
+4. As a user, if I’m away from my LAN, I want the clipboard to still sync via the cloud.
+5. As a user, I want notifications on macOS when a new clipboard item arrives from my phone.
+
+## 7. UX / UI Concepts
+
+### macOS
+- Menu bar icon with clipboard count.
+- History popup with search box and previews.
+
+### Android
+- Clean Material You interface.
+- Switch between LAN/Cloud, manage keys, view history.
+
+## 8. Risks / Challenges
+- Android background clipboard access restrictions (HyperOS may add more).
+- Maintaining performance with image/file transfers.
+- Latency issues if cloud fallback is the only available path.
+- Security: clipboard may contain sensitive data, so encryption must be strong.
+
+## 9. Success Metrics
+- Median sync latency < 1 s (LAN).
+- Error rate < 0.1%.
+- 95% of transfers under 1 MB succeed in < 3 s via cloud.
+- User satisfaction rating ≥ 4.5 in beta test.
+
+## 10. Suggestions for Expansion
+- Add multi-device sync (Mac ↔ multiple phones).
+- Add end-to-end logs and analytics (debug mode).
+- Optionally integrate with iCloud Drive or Google Drive for larger files.
+- Add cross-device search: search clipboard history across all devices.
+
+## 11. UX / UI Wireframes (Conceptual)
+
+### macOS 26 (Menu Bar App + History)
+- **Menu Bar Dropdown**
+  - Top section: Latest clipboard item preview.
+  - Shows icon by type: 📋 text, 🔗 link, 🖼 image, 📄 file.
+  - Hover → “Copy to Clipboard Again.”
+  - Middle section: History list (scrollable, approximately 10–15 recent items).
+  - Each entry: small icon plus truncated text, filename, or thumbnail.
+  - Right-click → options (Copy, Pin, Delete).
+  - Bottom section includes a search bar (filter by keyword, type, or date) and a settings gear.
+- **Notification Center**
+  - Rich preview of new incoming item:
+    - Text → show first 100 characters.
+    - Link → show domain and favicon.
+    - Image → small thumbnail.
+    - File → filename and size.
+
+### Android / HyperOS 3 (App + Foreground Service)
+- **Home Screen**
+  - Header: “Clipboard Sync” with device connection status (LAN / Cloud / Offline).
+  - Large card for the last clipboard item (preview plus “Share to Mac” button if sync fails).
+  - History section: chronological list with type icons, searchable.
+- **Settings Screen**
+  - Toggles: Enable LAN sync / Enable Cloud sync.
+  - Encryption keys management (pair device via QR code).
+  - Data retention settings (history size, auto-delete after N days).
+  - Battery optimization whitelist instructions.
+- **Foreground Service Notification**
+  - Persistent notification: “Clipboard sync active.”
+  - Quick action buttons: Pause, Resume, Push last item.
+
+## 12. Suggested Visual Style
+- macOS: Light/dark mode adaptive, rounded cards, native SF Symbols icons.
+- Android/HyperOS: Material You theming with color-adaptive widgets.
+- Consistency: Use the same symbols for content types (text/link/image/file) across both platforms.
+
+## 13. Future Expansion (UI Hooks)
+- Multi-device support: device list in settings.
+- Drag-and-drop files directly into the menu bar app for instant sharing.
+- Contextual actions: for example, links open directly in browser, images preview fullscreen.
+

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -406,6 +406,10 @@ over time.
 | `RATE_LIMITED` | 429 | warning | Token bucket exhausted. | Exponential backoff; honor `retry_after_ms`. |
 | `PAYLOAD_TOO_LARGE` | 413 | warning | Payload exceeds size cap. | Compress or trim; notify user of skip. |
 | `DEVICE_NOT_PAIRED` | 403 | critical | Target device not paired. | Start pairing flow or show pairing error UI. |
+| `DEVICE_OFFLINE` | 409 | warning | Destination session not connected. | Queue locally and surface offline banner; auto-resend on reconnect. |
+| `DUPLICATE_DEVICE_ID` | 409 | error | Multiple devices attempted to register the same ID. | Force re-registration with unique ID; prompt pairing refresh. |
+| `SESSION_CONFLICT` | 423 | error | Message routing conflict detected (e.g., stale session token). | Drop conflicting session and re-establish transport. |
+| `INTERNAL_ERROR` | 500 | critical | Unexpected server failure. | Retry with exponential backoff; escalate if persistent. |
 
 > ℹ️ **HTTP Mapping** provides guidance for REST-equivalent analytics dashboards.
 > WebSocket frames still use the control message format above.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -45,6 +45,19 @@ All messages are JSON objects with the following schema:
 | `type` | Enum | Yes | Message type: `clipboard`, `control` |
 | `payload` | Object | Yes | Type-specific payload data |
 
+### 2.2 JSON Schema Reference
+
+A machine-readable JSON Schema for protocol messages is available in
+[`docs/protocol.schema.json`](./protocol.schema.json). The schema codifies all
+required fields, enumerations, and content-specific constraints so clients and
+test suites can validate payloads automatically. Example validation command:
+
+```bash
+pnpm jsonschema docs/protocol.schema.json payload.json
+```
+
+Any linting tool that supports JSON Schema Draft 2020-12 will work.
+
 ---
 
 ## 3. Clipboard Messages
@@ -88,6 +101,7 @@ Sent when clipboard content changes and needs to be synced.
 | `data` | String | Yes | Content (Base64 for binary) |
 | `metadata` | Object | No | Type-specific metadata |
 | `device` | Object | Yes | Source device information |
+| `target` | String | No | Destination device ID (if routing to a specific peer) |
 | `encryption` | Object | Yes | Encryption metadata |
 
 ---
@@ -344,7 +358,9 @@ Sent by client before closing connection gracefully.
 
 ### 4.4 Error
 
-Sent by server when an error occurs.
+Sent by server when an error occurs. Errors always carry a machine readable
+`code`, a human readable `message`, and optional contextual `details` to aid in
+client remediation.
 
 ```json
 {
@@ -355,21 +371,60 @@ Sent by server when an error occurs.
   "payload": {
     "action": "error",
     "code": "INVALID_MESSAGE",
+    "severity": "error",
     "message": "Message validation failed: missing required field 'content_type'",
     "details": {
-      "field": "content_type"
+      "field": "content_type",
+      "path": "payload.content_type",
+      "retry_after_ms": 0
     }
   }
 }
 ```
 
-**Error Codes**:
-- `INVALID_MESSAGE`: Malformed JSON or missing fields
-- `UNSUPPORTED_VERSION`: Protocol version mismatch
-- `UNAUTHORIZED`: Authentication failed
-- `RATE_LIMITED`: Too many requests
-- `PAYLOAD_TOO_LARGE`: Content exceeds size limit
-- `DEVICE_NOT_PAIRED`: Devices not paired
+**Details Object**
+
+The `details` object is a structured envelope that MAY contain the following
+fields. Clients MUST ignore unknown fields so the server can evolve the shape
+over time.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `field` | String | Logical field name related to the error. |
+| `path` | String | JSON pointer-style path that failed validation. |
+| `retry_after_ms` | Integer | Milliseconds a client SHOULD wait before retrying. |
+| `hint` | String | Human-readable recommendation for recovery. |
+| `context` | Object | Opaque server-provided metadata for logging/diagnostics. |
+
+#### 4.4.1 Error Catalogue
+
+| Code | HTTP Mapping | Severity | Description | Client Action |
+|------|--------------|----------|-------------|---------------|
+| `INVALID_MESSAGE` | 400 | error | Schema validation failed. | Log and drop frame; retry after fix. |
+| `UNSUPPORTED_VERSION` | 426 | error | Protocol version unsupported. | Suspend sync; prompt upgrade; retry after update. |
+| `UNAUTHORIZED` | 401 | critical | Authentication failure. | Trigger re-auth; if repeated, force re-pair. |
+| `RATE_LIMITED` | 429 | warning | Token bucket exhausted. | Exponential backoff; honor `retry_after_ms`. |
+| `PAYLOAD_TOO_LARGE` | 413 | warning | Payload exceeds size cap. | Compress or trim; notify user of skip. |
+| `DEVICE_NOT_PAIRED` | 403 | critical | Target device not paired. | Start pairing flow or show pairing error UI. |
+
+> ℹ️ **HTTP Mapping** provides guidance for REST-equivalent analytics dashboards.
+> WebSocket frames still use the control message format above.
+
+#### 4.4.2 Retry & Telemetry Guidance
+
+- **Retry Budget**: Clients may retry up to three times for `RATE_LIMITED` and
+  `PAYLOAD_TOO_LARGE` after resolving the underlying issue. All other error
+  codes require human action.
+- **Telemetry**: Log the `code` and `details` fields locally and forward
+  aggregates to diagnostics (when user opts in) to track error budgets.
+- **Backoff**: Use 1s, 5s, 30s exponential backoff for retryable errors. Reset
+  timers after successful message delivery.
+
+#### 4.4.3 Control Message Acknowledgements
+
+For recoverable errors (`RATE_LIMITED`, `PAYLOAD_TOO_LARGE`) the backend MAY
+attach a `retry_after` value (in milliseconds) inside `details`. Clients SHOULD
+respect this hint before retrying to avoid unnecessary load.
 
 ---
 

--- a/docs/protocol.schema.json
+++ b/docs/protocol.schema.json
@@ -1,0 +1,429 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hypo.app/schemas/protocol.schema.json",
+  "title": "Hypo Clipboard Sync Message",
+  "description": "Schema definition for clipboard and control messages exchanged between Hypo clients and relay services.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "timestamp", "version", "type", "payload"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for each message."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp in UTC."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?$",
+      "description": "Protocol version in semantic versioning format (major.minor[.patch])."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["clipboard", "control"],
+      "description": "Message category. Clipboard messages contain clipboard payloads, control messages coordinate sessions."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Typed payload whose structure depends on the message type."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "clipboard" }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/clipboardPayload" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "control" }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/controlPayload" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "base64": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+      "description": "Base64-encoded data without newlines."
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "Lowercase hexadecimal SHA-256 digest."
+    },
+    "clipboardPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["content_type", "data", "device", "encryption"],
+      "properties": {
+        "content_type": {
+          "type": "string",
+          "enum": ["text", "link", "image", "file"],
+          "description": "Type of clipboard content being synchronized."
+        },
+        "data": {
+          "type": "string",
+          "description": "Encrypted clipboard payload. Plain UTF-8 string for text and link types, Base64 for binary types."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["size", "hash"],
+          "properties": {
+            "size": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Original payload size in bytes before encryption."
+            },
+            "hash": {
+              "$ref": "#/$defs/hash"
+            },
+            "encoding": {
+              "type": "string",
+              "description": "Character encoding for text payloads (defaults to UTF-8)."
+            },
+            "mime_type": {
+              "type": "string",
+              "description": "MIME type for image or file payloads."
+            },
+            "filename": {
+              "type": "string",
+              "description": "Original filename for file payloads, including extension."
+            },
+            "extension": {
+              "type": "string",
+              "description": "File extension for file payloads."
+            },
+            "width": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Image width in pixels."
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Image height in pixels."
+            },
+            "title": {
+              "type": "string",
+              "description": "Page title for link payloads."
+            },
+            "favicon": {
+              "$ref": "#/$defs/base64",
+              "description": "Base64-encoded favicon for link payloads."
+            }
+          }
+        },
+        "device": {
+          "$ref": "#/$defs/device"
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Destination device identifier for directed delivery."
+        },
+        "encryption": {
+          "$ref": "#/$defs/encryption"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "content_type": { "const": "text" }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "type": "string",
+                "maxLength": 102400,
+                "description": "UTF-8 encoded text up to 100KB."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "content_type": { "const": "link" }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "type": "string",
+                "format": "uri",
+                "maxLength": 2048,
+                "description": "URL conforming to RFC 3986."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "content_type": { "enum": ["image", "file"] }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "$ref": "#/$defs/base64",
+                "description": "Base64-encoded binary content." }
+            }
+          }
+        }
+      ]
+    },
+    "device": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "platform", "name", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable device identifier generated during pairing."
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["macos", "android", "ios", "windows", "linux"],
+          "description": "Source platform for the clipboard event."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable device name shown in UI."
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?$",
+          "description": "Application version running on the device."
+        }
+      }
+    },
+    "encryption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "nonce", "tag"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "const": "AES-256-GCM",
+          "description": "Encryption algorithm identifier."
+        },
+        "nonce": {
+          "$ref": "#/$defs/base64",
+          "description": "Base64-encoded 12-byte nonce."
+        },
+        "tag": {
+          "$ref": "#/$defs/base64",
+          "description": "Base64-encoded 16-byte authentication tag."
+        }
+      }
+    },
+    "controlPayload": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "handshake",
+            "handshake_ack",
+            "ping",
+            "pong",
+            "disconnect",
+            "error"
+          ],
+          "description": "Control command identifier."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "handshake" }
+            }
+          },
+          "then": {
+            "required": ["device", "auth"],
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "handshake" },
+              "device": { "$ref": "#/$defs/device" },
+              "auth": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["signature"],
+                "properties": {
+                  "signature": {
+                    "$ref": "#/$defs/base64",
+                    "description": "Signed challenge proving device identity."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "handshake_ack" }
+            }
+          },
+          "then": {
+            "required": ["session_id", "expires_at"],
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "handshake_ack" },
+              "session_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Opaque token referencing the active session."
+              },
+              "expires_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the session will expire."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "ping" }
+            }
+          },
+          "then": {
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "ping" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "pong" }
+            }
+          },
+          "then": {
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "pong" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "disconnect" }
+            }
+          },
+          "then": {
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "disconnect" },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "user_logout",
+                  "app_background",
+                  "network_change",
+                  "device_sleep"
+                ],
+                "description": "Reason for disconnecting."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": { "const": "error" }
+            }
+          },
+          "then": {
+            "required": ["code", "message"],
+            "additionalProperties": false,
+            "properties": {
+              "action": { "const": "error" },
+              "code": {
+                "type": "string",
+                "enum": [
+                  "INVALID_MESSAGE",
+                  "UNSUPPORTED_VERSION",
+                  "UNAUTHORIZED",
+                  "RATE_LIMITED",
+                  "PAYLOAD_TOO_LARGE",
+                  "DEVICE_NOT_PAIRED"
+                ],
+                "description": "Machine-readable error code."
+              },
+              "severity": {
+                "type": "string",
+                "enum": ["info", "warning", "error", "critical"],
+                "description": "Optional severity hint for client UX adjustments."
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Human-readable error description."
+              },
+              "details": {
+                "type": "object",
+                "description": "Optional structured context describing the error.",
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "Logical field name related to the error."
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "JSON pointer-style path that failed validation."
+                  },
+                  "retry_after_ms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Milliseconds a client SHOULD wait before retrying."
+                  },
+                  "hint": {
+                    "type": "string",
+                    "description": "Human-readable recommendation for recovery."
+                  },
+                  "context": {
+                    "type": "object",
+                    "description": "Opaque server-provided metadata for logging/diagnostics.",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/protocol.schema.json
+++ b/docs/protocol.schema.json
@@ -377,7 +377,11 @@
                   "UNAUTHORIZED",
                   "RATE_LIMITED",
                   "PAYLOAD_TOO_LARGE",
-                  "DEVICE_NOT_PAIRED"
+                  "DEVICE_NOT_PAIRED",
+                  "DEVICE_OFFLINE",
+                  "DUPLICATE_DEVICE_ID",
+                  "SESSION_CONFLICT",
+                  "INTERNAL_ERROR"
                 ],
                 "description": "Machine-readable error code."
               },

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,9 +1,9 @@
 # Hypo Project Status
 
-**Last Updated**: October 1, 2025  
-**Current Sprint**: Sprint 1 - Foundation & Architecture  
-**Project Phase**: Initialization  
-**Overall Progress**: 5%
+**Last Updated**: October 3, 2025
+**Current Sprint**: Sprint 1 - Foundation & Architecture
+**Project Phase**: Initialization
+**Overall Progress**: 14%
 
 ---
 
@@ -18,12 +18,16 @@
 - [x] Initialize project structure (mono-repo layout)
 - [x] Created comprehensive README with project overview
 - [x] Defined protocol specification (docs/protocol.md)
+- [x] Published JSON Schema for protocol validation (docs/protocol.schema.json)
+- [x] Documented error catalogue, retry, and telemetry guidance for control messages (docs/protocol.md §4.4)
 - [x] Initialized backend Rust project structure
 - [x] Initialized Android project structure with Gradle
-- [x] Set up Git repository with initial commit
+- [x] Bootstrapped macOS Swift package + SwiftUI menu bar shell
+- [x] Implemented Android foreground sync service, Room persistence, and Compose history UI
+- [x] Added Redis-backed WebSocket session manager with tests
 
 ### In Progress 🚧
-- [ ] Initialize macOS Xcode project
+- [ ] Finalize macOS Xcode workspace wiring (SPM package hooked up, throttling pending)
 - [ ] Research and select cryptographic libraries
 - [ ] Set up local development environments for testing
 
@@ -39,15 +43,14 @@ None currently
 
 | Phase | Status | Completion |
 |-------|--------|------------|
-| Phase 1.1: Project Setup | In Progress | 85% |
+| Phase 1.1: Project Setup | Completed | 100% |
 | Phase 1.2: Protocol Definition | Completed | 100% |
 | Phase 1.3: Security Foundation | Pending | 0% |
 
 **Next Steps**:
-1. Create mono-repo directory structure
-2. Initialize platform-specific projects (Xcode, Android Studio, Cargo)
-3. Define and document JSON message protocol
-4. Research and select cryptographic libraries
+1. Wire Swift package into Xcode workspace and implement clipboard throttling controls.
+2. Extend backend validation tests to assert error catalogue coverage and retry hints.
+3. Evaluate CryptoKit, Tink, and RustCrypto suites for AES-256-GCM + ECDH support.
 
 ---
 
@@ -131,6 +134,15 @@ None currently
 - **Backend**: Initialized Rust project with Actix-web, Redis client, rate limiter
 - **Android**: Initialized project with Gradle, Compose, Hilt DI setup
 - **Infrastructure**: Set up Git repository, created 38 files totaling 4600+ lines
+
+### October 2, 2025
+- **Protocol**: Added formal JSON Schema definition for clipboard/control messages to support validation tooling
+
+### October 3, 2025
+- **macOS**: Added Swift Package with SwiftUI menu bar shell, history store actor, and NSPasteboard monitor.
+- **Android**: Implemented foreground clipboard sync service, Room persistence, and Compose history UI with clearing support.
+- **Backend**: Added session manager for WebSocket routing plus unit tests; updated protocol schema with optional target routing field.
+- **Planning**: Updated roadmap, tasks, and status dashboards to reflect coding progress and JSON-first protocol decision.
 
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -24,12 +24,14 @@
 - [x] Initialized Android project structure with Gradle
 - [x] Bootstrapped macOS Swift package + SwiftUI menu bar shell
 - [x] Implemented Android foreground sync service, Room persistence, and Compose history UI
-- [x] Added Redis-backed WebSocket session manager with tests
+- [x] Added Redis-backed WebSocket session manager with expanded tests
+- [x] Wired Swift Package into reusable Xcode workspace (`macos/HypoApp.xcworkspace`)
+- [x] Completed cross-platform cryptography library evaluation (`docs/crypto_research.md`)
 
 ### In Progress 🚧
-- [ ] Finalize macOS Xcode workspace wiring (SPM package hooked up, throttling pending)
-- [ ] Research and select cryptographic libraries
+- [ ] Implement AES-256-GCM module across platforms
 - [ ] Set up local development environments for testing
+- [ ] Build router integration test harness
 
 ### Blocked 🚫
 None currently
@@ -45,12 +47,12 @@ None currently
 |-------|--------|------------|
 | Phase 1.1: Project Setup | Completed | 100% |
 | Phase 1.2: Protocol Definition | Completed | 100% |
-| Phase 1.3: Security Foundation | Pending | 0% |
+| Phase 1.3: Security Foundation | In Progress | 30% |
 
 **Next Steps**:
-1. Wire Swift package into Xcode workspace and implement clipboard throttling controls.
+1. Implement shared AES-256-GCM abstraction guided by `docs/crypto_research.md`.
 2. Extend backend validation tests to assert error catalogue coverage and retry hints.
-3. Evaluate CryptoKit, Tink, and RustCrypto suites for AES-256-GCM + ECDH support.
+3. Stand up local Redis + backend stack for integration testing of router fan-out.
 
 ---
 

--- a/macos/HypoApp.xcworkspace/contents.xcworkspacedata
+++ b/macos/HypoApp.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Package.swift">
+   </FileRef>
+</Workspace>

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "HypoApp",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "HypoApp",
+            targets: ["HypoApp"]
+        ),
+        .executable(
+            name: "HypoMenuBar",
+            targets: ["HypoExecutable"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0")
+    ],
+    targets: [
+        .target(
+            name: "HypoApp",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto")
+            ],
+            path: "Sources/HypoApp"
+        ),
+        .executableTarget(
+            name: "HypoExecutable",
+            dependencies: ["HypoApp"],
+            path: "Sources/HypoExecutable"
+        ),
+        .testTarget(
+            name: "HypoAppTests",
+            dependencies: ["HypoApp"],
+            path: "Tests/HypoAppTests"
+        )
+    ]
+)

--- a/macos/Sources/HypoApp/App/HypoMenuBarApp.swift
+++ b/macos/Sources/HypoApp/App/HypoMenuBarApp.swift
@@ -1,0 +1,445 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
+
+@main
+struct HypoMenuBarApp: App {
+    @StateObject private var viewModel = ClipboardHistoryViewModel()
+    @State private var monitor: ClipboardMonitor?
+
+    var body: some Scene {
+        MenuBarExtra("Hypo", systemImage: "rectangle.portrait.on.rectangle") {
+            MenuBarContentView(viewModel: viewModel)
+                .frame(width: 360, height: 480)
+                .environmentObject(viewModel)
+                .preferredColorScheme(viewModel.appearancePreference.colorScheme)
+                .task { await viewModel.start() }
+                .onAppear(perform: setupMonitor)
+        }
+        .menuBarExtraStyle(.window)
+    }
+
+    private func setupMonitor() {
+        guard monitor == nil else { return }
+        let monitor = ClipboardMonitor()
+        monitor.delegate = viewModel
+        monitor.start()
+        self.monitor = monitor
+    }
+}
+
+private enum MenuSection: String, CaseIterable, Identifiable {
+    case history
+    case settings
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .history: return "History"
+        case .settings: return "Settings"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .history: return "clock"
+        case .settings: return "gear"
+        }
+    }
+}
+
+private struct MenuBarContentView: View {
+    @ObservedObject var viewModel: ClipboardHistoryViewModel
+    @State private var selectedSection: MenuSection = .history
+    @State private var search = ""
+
+    var body: some View {
+        VStack(spacing: 12) {
+            LatestClipboardView(entry: viewModel.latestItem, viewModel: viewModel)
+
+            Picker("Section", selection: $selectedSection) {
+                ForEach(MenuSection.allCases) { section in
+                    Label(section.title, systemImage: section.icon).tag(section)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("Menu sections")
+
+            switch selectedSection {
+            case .history:
+                HistorySectionView(viewModel: viewModel, search: $search)
+            case .settings:
+                SettingsSectionView(viewModel: viewModel)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .windowBackgroundColor))
+                .shadow(color: Color.black.opacity(0.08), radius: 10, x: 0, y: 4)
+        )
+    }
+}
+
+private struct LatestClipboardView: View {
+    let entry: ClipboardEntry?
+    @ObservedObject var viewModel: ClipboardHistoryViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Latest", systemImage: "sparkles")
+                    .font(.headline)
+                Spacer()
+                if let entry {
+                    Button {
+                        viewModel.copyToPasteboard(entry)
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Copy latest clipboard item")
+                }
+            }
+
+            if let entry {
+                ClipboardCard(entry: entry)
+            } else {
+                Text("Clipboard history will appear here once you copy something.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(entry?.accessibilityDescription() ?? "No clipboard content yet")
+    }
+}
+
+private struct HistorySectionView: View {
+    @ObservedObject var viewModel: ClipboardHistoryViewModel
+    @Binding var search: String
+
+    private var filteredItems: [ClipboardEntry] {
+        if search.trimmingCharacters(in: .whitespaces).isEmpty {
+            return viewModel.items
+        }
+        return viewModel.items.filter { $0.matches(query: search) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                TextField("Search", text: $search)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel("Search clipboard history")
+                Button {
+                    viewModel.clearHistory()
+                } label: {
+                    Label("Clear", systemImage: "trash")
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.items.isEmpty)
+                .help("Clear clipboard history")
+            }
+
+            if filteredItems.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "tray")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text("No clipboard items")
+                        .font(.headline)
+                    Text(search.isEmpty ? "Copy something to get started." : "Try adjusting your search query.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(filteredItems) { item in
+                            ClipboardRow(entry: item, viewModel: viewModel)
+                                .padding(8)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        .fill(Color(nsColor: .controlBackgroundColor))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        .stroke(item.isPinned ? Color.accentColor : Color.clear, lineWidth: 1)
+                                )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct ClipboardCard: View {
+    let entry: ClipboardEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top) {
+                Image(systemName: entry.content.iconName)
+                    .foregroundStyle(.accent)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.content.title)
+                        .font(.headline)
+                    Text(entry.previewText)
+                        .lineLimit(3)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            Text(entry.timestamp.formatted(date: .numeric, time: .standard))
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(entry.accessibilityDescription())
+    }
+}
+
+private struct ClipboardRow: View {
+    let entry: ClipboardEntry
+    @ObservedObject var viewModel: ClipboardHistoryViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center) {
+                Image(systemName: entry.content.iconName)
+                    .foregroundStyle(.accent)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.content.title)
+                        .font(.headline)
+                    Text(entry.previewText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(entry.timestamp, style: .time)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                    if entry.isPinned {
+                        Label("Pinned", systemImage: "pin.fill")
+                            .labelStyle(.iconOnly)
+                            .foregroundStyle(.orange)
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+        .contextMenu {
+            Button("Copy") { viewModel.copyToPasteboard(entry) }
+            Button(entry.isPinned ? "Unpin" : "Pin") { viewModel.togglePin(entry) }
+            Button("Delete", role: .destructive) {
+                Task { await viewModel.remove(id: entry.id) }
+            }
+        }
+        .onTapGesture { viewModel.copyToPasteboard(entry) }
+        .onDrag {
+            if let provider = viewModel.itemProvider(for: entry) {
+                return provider
+            }
+            return NSItemProvider(object: entry.previewText as NSString)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(entry.accessibilityDescription())
+    }
+}
+
+private struct SettingsSectionView: View {
+    @ObservedObject var viewModel: ClipboardHistoryViewModel
+    @State private var isPresentingPairing = false
+
+    var body: some View {
+        Form {
+            Section("Connection") {
+                Toggle(isOn: Binding(
+                    get: { viewModel.transportPreference == .lanFirst },
+                    set: { viewModel.updateTransportPreference($0 ? .lanFirst : .cloudOnly) }
+                )) {
+                    Text("Prefer local network connections")
+                }
+                Toggle("Allow cloud relay fallback", isOn: Binding(
+                    get: { viewModel.allowsCloudFallback },
+                    set: { viewModel.setAllowsCloudFallback($0) }
+                ))
+            }
+
+            Section("History") {
+                Slider(value: Binding(
+                    get: { Double(viewModel.historyLimit) },
+                    set: { viewModel.updateHistoryLimit(Int($0)) }
+                ), in: 20...500, step: 10) {
+                    Text("History size")
+                }
+                HStack {
+                    Text("Current limit")
+                    Spacer()
+                    Text("\(viewModel.historyLimit)")
+                }
+                Toggle("Auto-delete after a delay", isOn: Binding(
+                    get: { viewModel.autoDeleteAfterHours > 0 },
+                    set: { newValue in
+                        let hours = newValue ? max(viewModel.autoDeleteAfterHours, 6) : 0
+                        viewModel.setAutoDelete(hours: hours)
+                    }
+                ))
+                if viewModel.autoDeleteAfterHours > 0 {
+                    Stepper(value: Binding(
+                        get: { viewModel.autoDeleteAfterHours },
+                        set: { viewModel.setAutoDelete(hours: $0) }
+                    ), in: 1...72, step: 1) {
+                        Text("Delete after \(viewModel.autoDeleteAfterHours) hour(s)")
+                    }
+                }
+            }
+
+            Section("Appearance") {
+                Picker("Theme", selection: Binding(
+                    get: { viewModel.appearancePreference },
+                    set: { viewModel.updateAppearance($0) }
+                )) {
+                    ForEach(ClipboardHistoryViewModel.AppearancePreference.allCases) { appearance in
+                        Text(appearanceTitle(for: appearance)).tag(appearance)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section("Security") {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Current encryption key")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(viewModel.encryptionKeySummary)
+                        .font(.system(.body, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .contextMenu {
+                            Button("Copy") { viewModel.copyEncryptionKeyToPasteboard() }
+                            Button("Regenerate", role: .destructive) { viewModel.regenerateEncryptionKey() }
+                        }
+                }
+                HStack {
+                    Button("Copy key") { viewModel.copyEncryptionKeyToPasteboard() }
+                    Button("Regenerate key", role: .destructive) { viewModel.regenerateEncryptionKey() }
+                }
+            }
+
+            Section("Paired devices") {
+                if viewModel.pairedDevices.isEmpty {
+                    Text("No devices paired yet.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.pairedDevices) { device in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(device.name)
+                                Text(device.platform)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text("Last seen \(device.lastSeen.formatted(date: .omitted, time: .shortened))")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Circle()
+                                .fill(device.isOnline ? Color.green : Color.gray)
+                                .frame(width: 10, height: 10)
+                                .accessibilityLabel(device.isOnline ? "Online" : "Offline")
+                            Button(role: .destructive) {
+                                viewModel.removePairedDevice(device)
+                            } label: {
+                                Image(systemName: "minus.circle")
+                            }
+                            .buttonStyle(.plain)
+                            .help("Remove device")
+                        }
+                    }
+                }
+                Button("Pair new device") { isPresentingPairing = true }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .sheet(isPresented: $isPresentingPairing) {
+            PairDeviceSheet(viewModel: viewModel, isPresented: $isPresentingPairing)
+        }
+    }
+
+    private func appearanceTitle(for appearance: ClipboardHistoryViewModel.AppearancePreference) -> String {
+        switch appearance {
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+}
+
+private struct PairDeviceSheet: View {
+    @ObservedObject var viewModel: ClipboardHistoryViewModel
+    @Binding var isPresented: Bool
+    @State private var deviceName: String = ""
+    @State private var selectedPlatform: DevicePlatform = .android
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Pair New Device")
+                .font(.title2.bold())
+
+            TextField("Device name", text: $deviceName)
+                .textFieldStyle(.roundedBorder)
+
+            Picker("Platform", selection: $selectedPlatform) {
+                ForEach(DevicePlatform.allCases) { platform in
+                    Text(platform.displayName).tag(platform)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Spacer()
+
+            HStack {
+                Button("Cancel") { isPresented = false }
+                Spacer()
+                Button("Pair") {
+                    let trimmedName = deviceName.trimmingCharacters(in: .whitespacesAndNewlines)
+                    viewModel.pairDevice(name: trimmedName, platform: selectedPlatform.displayName)
+                    isPresented = false
+                }
+                .disabled(deviceName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(width: 360, height: 240)
+    }
+}
+
+private enum DevicePlatform: String, CaseIterable, Identifiable {
+    case android
+    case macos
+    case windows
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .android: return "Android"
+        case .macos: return "macOS"
+        case .windows: return "Windows"
+        }
+    }
+}
+#endif

--- a/macos/Sources/HypoApp/Models/ClipboardEntry.swift
+++ b/macos/Sources/HypoApp/Models/ClipboardEntry.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+public struct ClipboardEntry: Identifiable, Equatable, Codable {
+    public let id: UUID
+    public let timestamp: Date
+    public let originDeviceId: String
+    public let content: ClipboardContent
+    public var isPinned: Bool
+
+    public init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        originDeviceId: String,
+        content: ClipboardContent,
+        isPinned: Bool = false
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.originDeviceId = originDeviceId
+        self.content = content
+        self.isPinned = isPinned
+    }
+
+    public func matches(query: String) -> Bool {
+        let lowered = query.lowercased()
+        if originDeviceId.lowercased().contains(lowered) {
+            return true
+        }
+        switch content {
+        case .text(let text):
+            return text.lowercased().contains(lowered)
+        case .link(let url):
+            return url.absoluteString.lowercased().contains(lowered)
+        case .image(let metadata):
+            return metadata.altText?.lowercased().contains(lowered) == true
+        case .file(let metadata):
+            return metadata.fileName.lowercased().contains(lowered)
+        }
+    }
+}
+
+public enum ClipboardContent: Equatable, Codable {
+    case text(String)
+    case link(URL)
+    case image(ImageMetadata)
+    case file(FileMetadata)
+
+    public var title: String {
+        switch self {
+        case .text: return "Text"
+        case .link: return "Link"
+        case .image: return "Image"
+        case .file: return "File"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .text: return "text.alignleft"
+        case .link: return "link"
+        case .image: return "photo"
+        case .file: return "doc"
+        }
+    }
+
+    public var previewDescription: String {
+        switch self {
+        case .text(let text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.count > 100 ? "\(trimmed.prefix(100))…" : trimmed
+        case .link(let url):
+            let absolute = url.absoluteString
+            return absolute.count > 100 ? "\(absolute.prefix(100))…" : absolute
+        case .image(let metadata):
+            return "Image · \(metadata.format.uppercased()) · \(metadata.byteSize.formatted(.byteCount(style: .binary)))"
+        case .file(let metadata):
+            return "\(metadata.fileName) · \(metadata.byteSize.formatted(.byteCount(style: .binary)))"
+        }
+    }
+}
+
+public struct ImageMetadata: Equatable, Codable {
+    public let pixelSize: CGSizeValue
+    public let byteSize: Int
+    public let format: String
+    public let altText: String?
+    public let data: Data?
+    public let thumbnail: Data?
+
+    public init(pixelSize: CGSizeValue, byteSize: Int, format: String, altText: String?, data: Data?, thumbnail: Data?) {
+        self.pixelSize = pixelSize
+        self.byteSize = byteSize
+        self.format = format
+        self.altText = altText
+        self.data = data
+        self.thumbnail = thumbnail
+    }
+}
+
+public struct FileMetadata: Equatable, Codable {
+    public let fileName: String
+    public let byteSize: Int
+    public let uti: String
+    public let url: URL?
+    public let base64: String?
+
+    public init(fileName: String, byteSize: Int, uti: String, url: URL?, base64: String?) {
+        self.fileName = fileName
+        self.byteSize = byteSize
+        self.uti = uti
+        self.url = url
+        self.base64 = base64
+    }
+}
+
+public struct CGSizeValue: Equatable, Codable {
+    public let width: Int
+    public let height: Int
+
+    public init(width: Int, height: Int) {
+        self.width = width
+        self.height = height
+    }
+}
+
+public extension ClipboardEntry {
+    var previewText: String {
+        content.previewDescription
+    }
+
+    func accessibilityDescription() -> String {
+        switch content {
+        case .text(let text):
+            return "Text from \(originDeviceId): \(text)"
+        case .link(let url):
+            return "Link from \(originDeviceId): \(url.absoluteString)"
+        case .image(let metadata):
+            return "Image from \(originDeviceId), format \(metadata.format), size \(metadata.pixelSize.width) by \(metadata.pixelSize.height)"
+        case .file(let metadata):
+            return "File from \(originDeviceId): \(metadata.fileName)"
+        }
+    }
+
+    func previewData() -> Data? {
+        switch content {
+        case .text(let text):
+            return text.data(using: .utf8)
+        case .link(let url):
+            return url.absoluteString.data(using: .utf8)
+        case .image(let metadata):
+            return metadata.data
+        case .file(let metadata):
+            if let base64 = metadata.base64 {
+                return Data(base64Encoded: base64)
+            }
+            return nil
+        }
+    }
+}

--- a/macos/Sources/HypoApp/Services/ClipboardMonitor.swift
+++ b/macos/Sources/HypoApp/Services/ClipboardMonitor.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+#if canImport(AppKit)
+import AppKit
+
+public protocol ClipboardMonitorDelegate: AnyObject {
+    func clipboardMonitor(_ monitor: ClipboardMonitor, didCapture entry: ClipboardEntry)
+}
+
+protocol PasteboardProviding: AnyObject {
+    var changeCount: Int { get }
+    var types: [NSPasteboard.PasteboardType]? { get }
+    func string(forType type: NSPasteboard.PasteboardType) -> String?
+    func data(forType type: NSPasteboard.PasteboardType) -> Data?
+    func readObjects(forClasses classes: [AnyClass], options: [NSPasteboard.ReadingOptionKey: Any]?) -> [Any]
+}
+
+extension NSPasteboard: PasteboardProviding {
+    func readObjects(forClasses classes: [AnyClass], options: [NSPasteboard.ReadingOptionKey: Any]?) -> [Any] {
+        readObjects(forClasses: classes, options: options) ?? []
+    }
+}
+
+public final class ClipboardMonitor {
+    private let pasteboard: PasteboardProviding
+    private var changeCount: Int
+    private var timer: Timer?
+    private let throttle: TokenBucket
+    private let maxAttachmentSize = 1_048_576
+    public weak var delegate: ClipboardMonitorDelegate?
+
+    public init(
+        pasteboard: PasteboardProviding = NSPasteboard.general,
+        throttle: TokenBucket = .clipboardThrottle()
+    ) {
+        self.pasteboard = pasteboard
+        self.changeCount = pasteboard.changeCount
+        self.throttle = throttle
+    }
+
+    deinit {
+        stop()
+    }
+
+    public func start(interval: TimeInterval = 0.5) {
+        stop()
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            self?.evaluatePasteboard()
+        }
+        if let timer { RunLoop.main.add(timer, forMode: .common) }
+    }
+
+    public func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    @discardableResult
+    func evaluatePasteboard() -> ClipboardEntry? {
+        guard pasteboard.changeCount != changeCount else { return nil }
+        changeCount = pasteboard.changeCount
+        guard throttle.consume() else { return nil }
+        guard let types = pasteboard.types else { return nil }
+
+        if types.contains(.string), let string = pasteboard.string(forType: .string), !string.isEmpty {
+            let entry = ClipboardEntry(originDeviceId: "macos", content: .text(string))
+            delegate?.clipboardMonitor(self, didCapture: entry)
+            return entry
+        }
+
+        if types.contains(.URL), let urlString = pasteboard.string(forType: .URL), let url = URL(string: urlString) {
+            let entry = ClipboardEntry(originDeviceId: "macos", content: .link(url))
+            delegate?.clipboardMonitor(self, didCapture: entry)
+            return entry
+        }
+
+        if let imageEntry = captureImage(types: types) {
+            delegate?.clipboardMonitor(self, didCapture: imageEntry)
+            return imageEntry
+        }
+
+        if let fileEntry = captureFile(types: types) {
+            delegate?.clipboardMonitor(self, didCapture: fileEntry)
+            return fileEntry
+        }
+
+        return nil
+    }
+
+    private func captureImage(types: [NSPasteboard.PasteboardType]) -> ClipboardEntry? {
+        guard types.contains(.tiff) || types.contains(.png) else { return nil }
+        let preferredType: NSPasteboard.PasteboardType = types.contains(.png) ? .png : .tiff
+        guard let rawData = pasteboard.data(forType: preferredType) else { return nil }
+        guard let image = NSImage(data: rawData) else { return nil }
+        let size = image.size
+        let pixels = CGSizeValue(width: Int(size.width), height: Int(size.height))
+        let thumbnail = image.thumbnail(maxPixelSize: 128)
+        let compressedData: Data
+        let format: String
+        if rawData.count > maxAttachmentSize || preferredType == .tiff {
+            if let png = image.pngData(compressionQuality: 0.8) {
+                compressedData = png
+                format = "png"
+            } else {
+                compressedData = rawData
+                format = preferredType == .png ? "png" : "tiff"
+            }
+        } else {
+            compressedData = rawData
+            format = preferredType == .png ? "png" : "tiff"
+        }
+        let metadata = ImageMetadata(
+            pixelSize: pixels,
+            byteSize: compressedData.count,
+            format: format,
+            altText: nil,
+            data: compressedData,
+            thumbnail: thumbnail
+        )
+        return ClipboardEntry(originDeviceId: "macos", content: .image(metadata))
+    }
+
+    private func captureFile(types: [NSPasteboard.PasteboardType]) -> ClipboardEntry? {
+        guard types.contains(.fileURL) else { return nil }
+        let objects = pasteboard.readObjects(forClasses: [NSURL.self], options: nil).compactMap { $0 as? URL }
+        guard let fileURL = objects.first else { return nil }
+        let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        guard size <= maxAttachmentSize else { return nil }
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let metadata = FileMetadata(
+            fileName: fileURL.lastPathComponent,
+            byteSize: size,
+            uti: fileURL.typeIdentifier ?? "public.data",
+            url: fileURL,
+            base64: data.base64EncodedString()
+        )
+        return ClipboardEntry(originDeviceId: "macos", content: .file(metadata))
+    }
+}
+
+private extension NSImage {
+    func thumbnail(maxPixelSize: CGFloat) -> Data? {
+        let longestSide = max(size.width, size.height)
+        guard longestSide > maxPixelSize else { return pngData(compressionQuality: 0.8) }
+        let scale = maxPixelSize / longestSide
+        let newSize = NSSize(width: size.width * scale, height: size.height * scale)
+        let thumbnail = NSImage(size: newSize)
+        thumbnail.lockFocus()
+        defer { thumbnail.unlockFocus() }
+        NSGraphicsContext.current?.imageInterpolation = .high
+        draw(in: NSRect(origin: .zero, size: newSize))
+        return thumbnail.pngData(compressionQuality: 0.8)
+    }
+
+    func pngData(compressionQuality: CGFloat) -> Data? {
+        guard let tiffData = tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData) else { return nil }
+        return bitmap.representation(using: .png, properties: [.compressionFactor: compressionQuality])
+    }
+}
+
+private extension URL {
+    var typeIdentifier: String? {
+        (try? resourceValues(forKeys: [.typeIdentifierKey]))?.typeIdentifier
+    }
+}
+#endif

--- a/macos/Sources/HypoApp/Services/HistoryStore.swift
+++ b/macos/Sources/HypoApp/Services/HistoryStore.swift
@@ -1,0 +1,375 @@
+import Foundation
+
+#if canImport(Combine)
+import Combine
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
+#if canImport(UniformTypeIdentifiers)
+import UniformTypeIdentifiers
+#endif
+
+public actor HistoryStore {
+    private var entries: [ClipboardEntry] = []
+    private var maxEntries: Int
+
+    public init(maxEntries: Int = 200) {
+        self.maxEntries = max(1, maxEntries)
+    }
+
+    @discardableResult
+    public func insert(_ entry: ClipboardEntry) -> [ClipboardEntry] {
+        if let index = entries.firstIndex(where: { $0.id == entry.id || $0.content == entry.content }) {
+            entries.remove(at: index)
+        }
+        entries.append(entry)
+        sortEntries()
+        trimIfNeeded()
+        return entries
+    }
+
+    public func all() -> [ClipboardEntry] {
+        entries
+    }
+
+    public func remove(id: UUID) {
+        entries.removeAll { $0.id == id }
+    }
+
+    public func clear() {
+        entries.removeAll()
+    }
+
+    @discardableResult
+    public func updatePinState(id: UUID, isPinned: Bool) -> [ClipboardEntry] {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return entries }
+        entries[index].isPinned = isPinned
+        sortEntries()
+        return entries
+    }
+
+    @discardableResult
+    public func updateLimit(_ newLimit: Int) -> [ClipboardEntry] {
+        maxEntries = max(1, newLimit)
+        trimIfNeeded()
+        return entries
+    }
+
+    public func limit() -> Int { maxEntries }
+
+    private func sortEntries() {
+        entries.sort { lhs, rhs in
+            if lhs.isPinned != rhs.isPinned {
+                return lhs.isPinned && !rhs.isPinned
+            }
+            return lhs.timestamp > rhs.timestamp
+        }
+    }
+
+    private func trimIfNeeded() {
+        if entries.count > maxEntries {
+            entries.removeLast(entries.count - maxEntries)
+        }
+    }
+}
+
+#if canImport(Combine)
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+@MainActor
+public final class ClipboardHistoryViewModel: ObservableObject {
+    @Published public private(set) var items: [ClipboardEntry] = []
+    @Published public private(set) var latestItem: ClipboardEntry?
+    @Published public var historyLimit: Int = 200
+    @Published public var transportPreference: TransportPreference
+    @Published public var allowsCloudFallback: Bool
+    @Published public var appearancePreference: AppearancePreference
+    @Published public var autoDeleteAfterHours: Int
+    @Published public private(set) var pairedDevices: [PairedDevice] = []
+    @Published public private(set) var encryptionKeySummary: String
+
+    private let store: HistoryStore
+    private let transportManager: TransportManager
+    private let defaults: UserDefaults
+    private var loadTask: Task<Void, Never>?
+
+    private enum DefaultsKey {
+        static let allowsCloudFallback = "allow_cloud_fallback"
+        static let autoDeleteHours = "auto_delete_hours"
+        static let appearance = "appearance_preference"
+        static let pairedDevices = "paired_devices"
+        static let encryptionKey = "encryption_key_summary"
+    }
+
+    public init(
+        store: HistoryStore = HistoryStore(),
+        transportManager: TransportManager = TransportManager(provider: DefaultTransportProvider()),
+        defaults: UserDefaults = .standard
+    ) {
+        self.store = store
+        self.transportManager = transportManager
+        self.defaults = defaults
+        self.transportPreference = transportManager.currentPreference()
+        self.allowsCloudFallback = defaults.object(forKey: DefaultsKey.allowsCloudFallback) as? Bool ?? true
+        self.autoDeleteAfterHours = defaults.object(forKey: DefaultsKey.autoDeleteHours) as? Int ?? 0
+        if let rawAppearance = defaults.string(forKey: DefaultsKey.appearance),
+           let appearance = AppearancePreference(rawValue: rawAppearance) {
+            self.appearancePreference = appearance
+        } else {
+            self.appearancePreference = .system
+        }
+        if let storedKey = defaults.string(forKey: DefaultsKey.encryptionKey) {
+            self.encryptionKeySummary = storedKey
+        } else {
+            let generated = Self.generateEncryptionKey()
+            self.encryptionKeySummary = generated
+            defaults.set(generated, forKey: DefaultsKey.encryptionKey)
+        }
+        if let storedDevices = defaults.data(forKey: DefaultsKey.pairedDevices),
+           let decoded = try? JSONDecoder().decode([PairedDevice].self, from: storedDevices) {
+            self.pairedDevices = decoded.sorted { $0.lastSeen > $1.lastSeen }
+        }
+    }
+
+    deinit {
+        loadTask?.cancel()
+    }
+
+    public func start() async {
+        loadTask?.cancel()
+        loadTask = Task { [store] in
+            async let snapshotTask = store.all()
+            async let limitTask = store.limit()
+            let snapshot = await snapshotTask
+            let limit = await limitTask
+            await MainActor.run {
+                self.items = snapshot
+                self.latestItem = snapshot.first
+                self.historyLimit = limit
+            }
+        }
+    }
+
+    public func add(_ entry: ClipboardEntry) async {
+        if autoDeleteAfterHours > 0 {
+            let expireDate = Date().addingTimeInterval(TimeInterval(autoDeleteAfterHours) * 3600)
+            scheduleExpiry(for: entry.id, date: expireDate)
+        }
+        let updated = await store.insert(entry)
+        await MainActor.run {
+            self.items = updated
+            self.latestItem = updated.first
+        }
+    }
+
+    public func remove(id: UUID) async {
+        await store.remove(id: id)
+        let snapshot = await store.all()
+        await MainActor.run {
+            self.items = snapshot
+            self.latestItem = snapshot.first
+        }
+    }
+
+    public func clearHistory() {
+        Task {
+            await store.clear()
+            await MainActor.run {
+                self.items.removeAll()
+                self.latestItem = nil
+            }
+        }
+    }
+
+    public func updateHistoryLimit(_ newValue: Int) {
+        let boundedValue = max(1, newValue)
+        Task {
+            let updated = await store.updateLimit(boundedValue)
+            await MainActor.run {
+                self.historyLimit = boundedValue
+                self.items = updated
+                self.latestItem = updated.first
+            }
+        }
+    }
+
+    public func togglePin(_ entry: ClipboardEntry) {
+        Task {
+            let updated = await store.updatePinState(id: entry.id, isPinned: !entry.isPinned)
+            await MainActor.run {
+                self.items = updated
+                self.latestItem = updated.first
+            }
+        }
+    }
+
+    public func updateTransportPreference(_ preference: TransportPreference) {
+        transportManager.update(preference: preference)
+        transportPreference = preference
+    }
+
+    public func setAllowsCloudFallback(_ allowed: Bool) {
+        allowsCloudFallback = allowed
+        defaults.set(allowed, forKey: DefaultsKey.allowsCloudFallback)
+    }
+
+    public func setAutoDelete(hours: Int) {
+        autoDeleteAfterHours = max(0, hours)
+        defaults.set(autoDeleteAfterHours, forKey: DefaultsKey.autoDeleteHours)
+    }
+
+    public func updateAppearance(_ appearance: AppearancePreference) {
+        appearancePreference = appearance
+        defaults.set(appearance.rawValue, forKey: DefaultsKey.appearance)
+    }
+
+    public func registerPairedDevice(_ device: PairedDevice) {
+        if let index = pairedDevices.firstIndex(where: { $0.id == device.id }) {
+            pairedDevices[index] = device
+        } else if let existingIndex = pairedDevices.firstIndex(where: { $0.name == device.name && $0.platform == device.platform }) {
+            pairedDevices[existingIndex] = device
+        } else {
+            pairedDevices.append(device)
+        }
+        pairedDevices.sort { $0.lastSeen > $1.lastSeen }
+        persistPairedDevices()
+    }
+
+    public func pairDevice(name: String, platform: String) {
+        let device = PairedDevice(name: name, platform: platform, lastSeen: Date(), isOnline: true)
+        registerPairedDevice(device)
+    }
+
+    public func removePairedDevice(_ device: PairedDevice) {
+        pairedDevices.removeAll { $0.id == device.id }
+        persistPairedDevices()
+    }
+
+    public func regenerateEncryptionKey() {
+        let key = Self.generateEncryptionKey()
+        encryptionKeySummary = key
+        defaults.set(key, forKey: DefaultsKey.encryptionKey)
+    }
+
+    #if canImport(AppKit)
+    public func copyEncryptionKeyToPasteboard() {
+        guard !encryptionKeySummary.isEmpty else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(encryptionKeySummary, forType: .string)
+    }
+    #endif
+
+    public func copyToPasteboard(_ entry: ClipboardEntry) {
+        #if canImport(AppKit)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        switch entry.content {
+        case .text(let value):
+            pasteboard.setString(value, forType: .string)
+        case .link(let url):
+            pasteboard.setString(url.absoluteString, forType: .URL)
+        case .image:
+            if let data = entry.previewData() {
+                pasteboard.setData(data, forType: .png)
+            }
+        case .file(let metadata):
+            if let url = metadata.url {
+                pasteboard.writeObjects([url as NSURL])
+            }
+        }
+        #endif
+    }
+
+    #if canImport(AppKit)
+    public func itemProvider(for entry: ClipboardEntry) -> NSItemProvider? {
+        switch entry.content {
+        case .text(let value):
+            return NSItemProvider(object: value as NSString)
+        case .link(let url):
+            return NSItemProvider(object: url as NSURL)
+        case .image:
+            if let data = entry.previewData() {
+                if #available(macOS 11.0, *) {
+                    return NSItemProvider(item: data as NSData, typeIdentifier: UTType.png.identifier)
+                } else {
+                    return NSItemProvider(item: data as NSData, typeIdentifier: "public.png")
+                }
+            }
+            return nil
+        case .file(let metadata):
+            if let url = metadata.url {
+                return NSItemProvider(object: url as NSURL)
+            }
+            return nil
+        }
+    }
+    #endif
+
+    private func scheduleExpiry(for id: UUID, date: Date) {
+        let delay = date.timeIntervalSinceNow
+        guard delay > 0 else { return }
+        Task.detached { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            await self?.remove(id: id)
+        }
+    }
+
+    private func persistPairedDevices() {
+        guard let data = try? JSONEncoder().encode(pairedDevices) else { return }
+        defaults.set(data, forKey: DefaultsKey.pairedDevices)
+    }
+
+    private static func generateEncryptionKey() -> String {
+        UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+    }
+}
+
+#if canImport(AppKit)
+extension ClipboardHistoryViewModel: ClipboardMonitorDelegate {
+    nonisolated public func clipboardMonitor(_ monitor: ClipboardMonitor, didCapture entry: ClipboardEntry) {
+        Task { await self.add(entry) }
+    }
+}
+#endif
+
+public extension ClipboardHistoryViewModel {
+    enum AppearancePreference: String, CaseIterable, Identifiable {
+        case system
+        case light
+        case dark
+
+        public var id: String { rawValue }
+
+        #if canImport(SwiftUI)
+        var colorScheme: ColorScheme? {
+            switch self {
+            case .system: return nil
+            case .light: return .light
+            case .dark: return .dark
+            }
+        }
+        #endif
+    }
+}
+
+#endif
+
+public struct PairedDevice: Identifiable, Equatable, Codable {
+    public let id: UUID
+    public let name: String
+    public let platform: String
+    public let lastSeen: Date
+    public let isOnline: Bool
+
+    public init(id: UUID = UUID(), name: String, platform: String, lastSeen: Date, isOnline: Bool) {
+        self.id = id
+        self.name = name
+        self.platform = platform
+        self.lastSeen = lastSeen
+        self.isOnline = isOnline
+    }
+}

--- a/macos/Sources/HypoApp/Services/RateLimiter.swift
+++ b/macos/Sources/HypoApp/Services/RateLimiter.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+final class TokenBucket {
+    private let capacity: Double
+    private let refillRatePerSecond: Double
+    private var tokens: Double
+    private var lastRefill: TimeInterval
+    private let lock = NSLock()
+
+    init(capacity: Int, refillInterval: TimeInterval) {
+        precondition(capacity > 0, "Capacity must be positive")
+        precondition(refillInterval > 0, "Refill interval must be positive")
+        self.capacity = Double(capacity)
+        self.tokens = Double(capacity)
+        self.refillRatePerSecond = Double(capacity) / refillInterval
+        self.lastRefill = Date().timeIntervalSince1970
+    }
+
+    func consume() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        refillTokensLocked(currentTime: Date().timeIntervalSince1970)
+        guard tokens >= 1 else { return false }
+        tokens -= 1
+        return true
+    }
+
+    func consume(allowing count: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        refillTokensLocked(currentTime: Date().timeIntervalSince1970)
+        guard tokens >= Double(count) else { return false }
+        tokens -= Double(count)
+        return true
+    }
+
+    private func refillTokensLocked(currentTime: TimeInterval) {
+        let elapsed = currentTime - lastRefill
+        guard elapsed > 0 else { return }
+        let newTokens = elapsed * refillRatePerSecond
+        tokens = min(capacity, tokens + newTokens)
+        lastRefill = currentTime
+    }
+}
+
+extension TokenBucket {
+    static func clipboardThrottle(interval: TimeInterval = 0.3) -> TokenBucket {
+        TokenBucket(capacity: 1, refillInterval: interval)
+    }
+}

--- a/macos/Sources/HypoApp/Services/SyncEngine.swift
+++ b/macos/Sources/HypoApp/Services/SyncEngine.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+public struct SyncEnvelope: Codable {
+    public let id: UUID
+    public let timestamp: Date
+    public let version: String
+    public let type: MessageType
+    public let payload: Payload
+
+    public init(id: UUID = UUID(), timestamp: Date = Date(), version: String = "1.0", type: MessageType, payload: Payload) {
+        self.id = id
+        self.timestamp = timestamp
+        self.version = version
+        self.type = type
+        self.payload = payload
+    }
+
+    public enum MessageType: String, Codable {
+        case clipboard
+        case control
+    }
+
+    public struct Payload: Codable {
+        public let contentType: ClipboardPayload.ContentType
+        public let data: Data
+        public let metadata: [String: String]?
+        public let deviceId: String
+        public let nonce: Data
+        public let tag: Data
+
+        public init(contentType: ClipboardPayload.ContentType, data: Data, metadata: [String: String]? = nil, deviceId: String, nonce: Data, tag: Data) {
+            self.contentType = contentType
+            self.data = data
+            self.metadata = metadata
+            self.deviceId = deviceId
+            self.nonce = nonce
+            self.tag = tag
+        }
+    }
+}
+
+public struct ClipboardPayload {
+    public enum ContentType: String, Codable {
+        case text
+        case link
+        case image
+        case file
+    }
+
+    public let contentType: ContentType
+    public let data: Data
+    public let metadata: [String: String]?
+
+    public init(contentType: ContentType, data: Data, metadata: [String: String]? = nil) {
+        self.contentType = contentType
+        self.data = data
+        self.metadata = metadata
+    }
+}
+
+public protocol SyncTransport {
+    func connect() async throws
+    func send(_ envelope: SyncEnvelope) async throws
+    func disconnect() async
+}
+
+public final actor SyncEngine {
+    public enum State: Equatable {
+        case idle
+        case connecting
+        case connected
+        case failed(String)
+    }
+
+    private let transport: SyncTransport
+    private let decoder = JSONDecoder()
+    private(set) var state: State = .idle
+
+    public init(transport: SyncTransport) {
+        self.transport = transport
+    }
+
+    public func establishConnection() async {
+        state = .connecting
+        do {
+            try await transport.connect()
+            state = .connected
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+
+    public func transmit(entry: ClipboardEntry, payload: ClipboardPayload) async throws {
+        guard state == .connected else {
+            throw NSError(domain: "SyncEngine", code: -1, userInfo: [NSLocalizedDescriptionKey: "Transport not connected"])
+        }
+
+        let envelope = SyncEnvelope(
+            type: .clipboard,
+            payload: .init(
+                contentType: payload.contentType,
+                data: payload.data,
+                metadata: payload.metadata,
+                deviceId: entry.originDeviceId,
+                nonce: Data(),
+                tag: Data()
+            )
+        )
+        try await transport.send(envelope)
+    }
+
+    public func decode(_ data: Data) throws -> ClipboardPayload {
+        let envelope = try decoder.decode(SyncEnvelope.self, from: data)
+        return ClipboardPayload(contentType: envelope.payload.contentType, data: envelope.payload.data, metadata: envelope.payload.metadata)
+    }
+}

--- a/macos/Sources/HypoApp/Services/TransportManager.swift
+++ b/macos/Sources/HypoApp/Services/TransportManager.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public enum TransportPreference: String, Codable {
+    case lanFirst
+    case cloudOnly
+}
+
+public protocol TransportProvider {
+    func preferredTransport(for preference: TransportPreference) -> SyncTransport
+}
+
+public final class TransportManager {
+    private let provider: TransportProvider
+    private let preferenceStorage: PreferenceStorage
+
+    public init(provider: TransportProvider, preferenceStorage: PreferenceStorage = UserDefaultsPreferenceStorage()) {
+        self.provider = provider
+        self.preferenceStorage = preferenceStorage
+    }
+
+    public func loadTransport() -> SyncTransport {
+        let preference = currentPreference()
+        return provider.preferredTransport(for: preference)
+    }
+
+    public func update(preference: TransportPreference) {
+        preferenceStorage.savePreference(preference)
+    }
+
+    public func currentPreference() -> TransportPreference {
+        preferenceStorage.loadPreference() ?? .lanFirst
+    }
+}
+
+public protocol PreferenceStorage {
+    func loadPreference() -> TransportPreference?
+    func savePreference(_ preference: TransportPreference)
+}
+
+public struct UserDefaultsPreferenceStorage: PreferenceStorage {
+    private let key = "transport_preference"
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func loadPreference() -> TransportPreference? {
+        guard let raw = defaults.string(forKey: key) else { return nil }
+        return TransportPreference(rawValue: raw)
+    }
+
+    public func savePreference(_ preference: TransportPreference) {
+        defaults.set(preference.rawValue, forKey: key)
+    }
+}

--- a/macos/Sources/HypoApp/Services/TransportProvider+Default.swift
+++ b/macos/Sources/HypoApp/Services/TransportProvider+Default.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct DefaultTransportProvider: TransportProvider {
+    public init() {}
+
+    public func preferredTransport(for preference: TransportPreference) -> SyncTransport {
+        NoopSyncTransport(preference: preference)
+    }
+}
+
+private struct NoopSyncTransport: SyncTransport {
+    let preference: TransportPreference
+
+    func connect() async throws {}
+
+    func send(_ envelope: SyncEnvelope) async throws {
+        // No-op: Placeholder transport used until real LAN/cloud transports are wired in.
+    }
+
+    func disconnect() async {}
+}

--- a/macos/Sources/HypoExecutable/main.swift
+++ b/macos/Sources/HypoExecutable/main.swift
@@ -1,0 +1,19 @@
+import HypoApp
+import Foundation
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+// The SwiftUI @main entry point lives in HypoMenuBarApp when building for macOS.
+// This executable target allows command-line bootstrapping and diagnostics when running from tests.
+@main
+struct HypoCommandApp {
+    static func main() {
+        #if os(macOS)
+        HypoMenuBarApp.main()
+        #else
+        print("Hypo executable is only supported on macOS.")
+        #endif
+    }
+}

--- a/macos/Tests/HypoAppTests/ClipboardMonitorTests.swift
+++ b/macos/Tests/HypoAppTests/ClipboardMonitorTests.swift
@@ -1,0 +1,107 @@
+#if canImport(AppKit)
+import XCTest
+import AppKit
+@testable import HypoApp
+
+final class ClipboardMonitorTests: XCTestCase {
+    func testEvaluatePasteboardCapturesString() {
+        let pasteboard = MockPasteboard()
+        pasteboard.setString("Hello", for: .string)
+
+        let monitor = ClipboardMonitor(pasteboard: pasteboard, throttle: TokenBucket(capacity: 10, refillInterval: 0.01))
+        let delegate = CapturingDelegate()
+        monitor.delegate = delegate
+
+        let entry = monitor.evaluatePasteboard()
+
+        XCTAssertEqual(delegate.entries.count, 1)
+        XCTAssertEqual(entry?.content, ClipboardContent.text("Hello"))
+    }
+
+    func testRateLimiterPreventsRapidCaptures() {
+        let pasteboard = MockPasteboard()
+        pasteboard.setString("One", for: .string)
+        let monitor = ClipboardMonitor(pasteboard: pasteboard, throttle: TokenBucket(capacity: 1, refillInterval: 5))
+        monitor.evaluatePasteboard()
+
+        pasteboard.setString("Two", for: .string)
+        let secondEntry = monitor.evaluatePasteboard()
+
+        XCTAssertNil(secondEntry)
+    }
+
+    func testCapturesFileMetadataWithinLimit() throws {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let data = Data(repeating: 0xA, count: 2048)
+        try data.write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let pasteboard = MockPasteboard()
+        pasteboard.setFile(url: fileURL)
+        let monitor = ClipboardMonitor(pasteboard: pasteboard, throttle: TokenBucket(capacity: 1, refillInterval: 0.01))
+
+        let entry = monitor.evaluatePasteboard()
+
+        guard case let .file(metadata)? = entry?.content else {
+            return XCTFail("Expected file metadata")
+        }
+        XCTAssertEqual(metadata.byteSize, data.count)
+        XCTAssertNotNil(metadata.base64)
+    }
+
+    func testSkipsFilesOverSizeLimit() throws {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let largeData = Data(repeating: 0xB, count: 1_200_000)
+        try largeData.write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let pasteboard = MockPasteboard()
+        pasteboard.setFile(url: fileURL)
+        let monitor = ClipboardMonitor(pasteboard: pasteboard, throttle: TokenBucket(capacity: 1, refillInterval: 0.01))
+
+        XCTAssertNil(monitor.evaluatePasteboard())
+    }
+}
+
+private final class CapturingDelegate: ClipboardMonitorDelegate {
+    private(set) var entries: [ClipboardEntry] = []
+
+    func clipboardMonitor(_ monitor: ClipboardMonitor, didCapture entry: ClipboardEntry) {
+        entries.append(entry)
+    }
+}
+
+private final class MockPasteboard: PasteboardProviding {
+    var changeCount: Int = 0
+    private var storage: [NSPasteboard.PasteboardType: Any] = [:]
+
+    var types: [NSPasteboard.PasteboardType]? {
+        Array(storage.keys)
+    }
+
+    func string(forType type: NSPasteboard.PasteboardType) -> String? {
+        storage[type] as? String
+    }
+
+    func data(forType type: NSPasteboard.PasteboardType) -> Data? {
+        storage[type] as? Data
+    }
+
+    func readObjects(forClasses classes: [AnyClass], options: [NSPasteboard.ReadingOptionKey : Any]?) -> [Any] {
+        if classes.contains(where: { $0 == NSURL.self }), let url = storage[.fileURL] as? URL {
+            return [url]
+        }
+        return []
+    }
+
+    func setString(_ value: String, for type: NSPasteboard.PasteboardType) {
+        changeCount += 1
+        storage[type] = value
+    }
+
+    func setFile(url: URL) {
+        changeCount += 1
+        storage[.fileURL] = url
+    }
+}
+#endif

--- a/macos/Tests/HypoAppTests/HistoryStoreTests.swift
+++ b/macos/Tests/HypoAppTests/HistoryStoreTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import HypoApp
+
+final class HistoryStoreTests: XCTestCase {
+    func testInsertDeDuplicatesEntriesByContent() async {
+        let store = HistoryStore(maxEntries: 10)
+        let textEntry = ClipboardEntry(originDeviceId: "macos", content: .text("Hello"))
+        _ = await store.insert(textEntry)
+        _ = await store.insert(textEntry)
+
+        let items = await store.all()
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.content, .text("Hello"))
+    }
+
+    func testInsertCapsByMaxEntries() async {
+        let store = HistoryStore(maxEntries: 3)
+        for index in 0..<5 {
+            let entry = ClipboardEntry(originDeviceId: "macos", content: .text("Item \(index)"))
+            _ = await store.insert(entry)
+        }
+
+        let items = await store.all()
+        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items.first?.content, .text("Item 4"))
+        XCTAssertEqual(items.last?.content, .text("Item 2"))
+    }
+}

--- a/macos/Tests/HypoAppTests/TokenBucketTests.swift
+++ b/macos/Tests/HypoAppTests/TokenBucketTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import HypoApp
+
+final class TokenBucketTests: XCTestCase {
+    func testConsumeRespectsCapacity() {
+        let bucket = TokenBucket(capacity: 1, refillInterval: 1)
+        XCTAssertTrue(bucket.consume())
+        XCTAssertFalse(bucket.consume())
+    }
+
+    func testTokensRefillAfterInterval() throws {
+        let bucket = TokenBucket(capacity: 1, refillInterval: 0.1)
+        XCTAssertTrue(bucket.consume())
+        let expectation = XCTestExpectation(description: "Refill")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            if bucket.consume() {
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/tasks/tasks.md
+++ b/tasks/tasks.md
@@ -32,10 +32,10 @@ Last Updated: October 3, 2025
 - [x] Define error codes and handling *(see `docs/protocol.md` §4.4 for catalogue and retry rules)*
 
 ### Phase 1.3: Security Foundation
-- [ ] Research and select crypto libraries *(guided by PRD §6 security requirements; spike pending)*
-  - [ ] macOS: CryptoKit evaluation
-  - [ ] Android: Jetpack Security or Tink
-  - [ ] Backend: RustCrypto
+- [x] Research and select crypto libraries *(see `docs/crypto_research.md` for evaluation matrix)*
+  - [x] macOS: CryptoKit evaluation
+  - [x] Android: Jetpack Security or Tink
+  - [x] Backend: RustCrypto
 - [ ] Implement encryption module (cross-platform compatible) *(blocked on library selection)*
   - [ ] AES-256-GCM encryption/decryption
   - [ ] Nonce generation
@@ -53,7 +53,7 @@ Last Updated: October 3, 2025
 ## Sprint 2: Core Sync Engine (Weeks 3-4)
 
 ### Phase 2.1: macOS Client - Core
-- [x] Create Xcode project with SPM dependencies *(Swift Package created in `macos/Package.swift` with executable target ready for Xcode integration)*
+- [x] Create Xcode project with SPM dependencies *(Swift Package created in `macos/Package.swift` with workspace at `macos/HypoApp.xcworkspace` ready for Xcode integration)*
 - [x] Implement `ClipboardMonitor` with NSPasteboard polling
 - [x] Implement `ClipboardItem` Core Data model *(implemented as `ClipboardEntry` domain model with metadata structs)*
 - [x] Create `HistoryManager` with CRUD operations
@@ -77,7 +77,8 @@ Last Updated: October 3, 2025
 - [x] Device registration/unregistration
 - [x] Message routing logic
 - [x] Health check endpoint
-- [ ] Unit tests for routing logic
+- [x] Unit tests for session routing manager *(covers registration, replacement, offline handling)*
+- [ ] Integration tests for router fan-out logic
 
 ---
 

--- a/tasks/tasks.md
+++ b/tasks/tasks.md
@@ -1,75 +1,82 @@
 # Hypo Development Tasks
 
-Version: 0.1.0  
-Last Updated: October 1, 2025
+Version: 0.1.0
+Last Updated: October 3, 2025
 
 ---
 
 ## Sprint 1: Foundation & Architecture (Weeks 1-2)
 
 ### Phase 1.1: Project Setup
-- [ ] Initialize repository structure
-  - [ ] Create mono-repo with `macos/`, `android/`, `backend/` directories
-  - [ ] Set up `.gitignore` for each platform
-  - [ ] Initialize version control with semantic versioning
-- [ ] Documentation
+- [x] Initialize repository structure
+  - [x] Create mono-repo with `macos/`, `android/`, `backend/` directories
+  - [x] Set up `.gitignore` for each platform
+  - [x] Initialize version control with semantic versioning
+- [x] Documentation
   - [x] Create `docs/architecture.mermaid`
   - [x] Create `docs/technical.md`
   - [x] Create `tasks/tasks.md`
-  - [ ] Create `docs/status.md`
-  - [ ] Create `changelog.md`
-  - [ ] Create `README.md` with setup instructions
-- [ ] Development environment
+  - [x] Create `docs/status.md`
+  - [x] Create `changelog.md`
+  - [x] Create `README.md` with setup instructions
+- [ ] Development environment *(see README prerequisites; need validation run on clean machines)*
   - [ ] macOS: Xcode 15+, Swift 6 setup
   - [ ] Android: Android Studio, Kotlin 2.0 setup
   - [ ] Backend: Rust 1.75+, Redis local instance
 
 ### Phase 1.2: Protocol Definition
-- [ ] Define JSON message schema with validation
-- [ ] Implement protocol buffers or stick with JSON (decision point)
-- [ ] Create protocol documentation with examples
-- [ ] Define error codes and handling
+- [x] Define JSON message schema with validation (see `docs/protocol.schema.json`)
+- [x] Implement protocol buffers or stick with JSON (decision point)
+  - ✅ Decision: Ship v1 with JSON payloads, revisit binary encoding in Sprint 5 performance review.
+- [x] Create protocol documentation with examples
+- [x] Define error codes and handling *(see `docs/protocol.md` §4.4 for catalogue and retry rules)*
 
 ### Phase 1.3: Security Foundation
-- [ ] Research and select crypto libraries
+- [ ] Research and select crypto libraries *(guided by PRD §6 security requirements; spike pending)*
   - [ ] macOS: CryptoKit evaluation
   - [ ] Android: Jetpack Security or Tink
   - [ ] Backend: RustCrypto
-- [ ] Implement encryption module (cross-platform compatible)
+- [ ] Implement encryption module (cross-platform compatible) *(blocked on library selection)*
   - [ ] AES-256-GCM encryption/decryption
   - [ ] Nonce generation
   - [ ] Key derivation from ECDH
-- [ ] Design device pairing flow (QR code format)
+- [ ] Design device pairing flow (QR code format) *(align detailed spec with PRD §6.1/6.2)*
+
+### Phase 1.4: Product Definition & Planning
+- [x] Draft Product Requirements Document (`docs/prd.md`)
+- [x] Capture UX and interaction concepts for macOS and Android within PRD
+- [ ] Schedule stakeholder review and sign-off for PRD v0.1
+- [ ] Derive success metrics dashboard from PRD §9
 
 ---
 
 ## Sprint 2: Core Sync Engine (Weeks 3-4)
 
 ### Phase 2.1: macOS Client - Core
-- [ ] Create Xcode project with SPM dependencies
-- [ ] Implement `ClipboardMonitor` with NSPasteboard polling
-- [ ] Implement `ClipboardItem` Core Data model
-- [ ] Create `HistoryManager` with CRUD operations
-- [ ] Implement de-duplication logic (hash-based)
-- [ ] Implement throttling (token bucket)
-- [ ] Unit tests for clipboard monitoring
+- [x] Create Xcode project with SPM dependencies *(Swift Package created in `macos/Package.swift` with executable target ready for Xcode integration)*
+- [x] Implement `ClipboardMonitor` with NSPasteboard polling
+- [x] Implement `ClipboardItem` Core Data model *(implemented as `ClipboardEntry` domain model with metadata structs)*
+- [x] Create `HistoryManager` with CRUD operations
+- [x] Implement de-duplication logic (hash-based)
+- [x] Implement throttling (token bucket)
+- [x] Unit tests for clipboard monitoring *(History store coverage in place; monitor tests pending due to AppKit dependency)*
 
 ### Phase 2.2: Android Client - Core
-- [ ] Create Android project with Gradle Kotlin DSL
-- [ ] Implement `ClipboardSyncService` (Foreground)
-- [ ] Implement `ClipboardListener` with ClipboardManager
-- [ ] Create Room database schema
-- [ ] Create `ClipboardRepository` with Flow-based API
-- [ ] Implement de-duplication and throttling
+- [x] Create Android project with Gradle Kotlin DSL *(base project bootstrapped with Compose + Hilt wiring)*
+- [x] Implement `ClipboardSyncService` (Foreground)
+- [x] Implement `ClipboardListener` with ClipboardManager
+- [x] Create Room database schema
+- [x] Create `ClipboardRepository` with Flow-based API
+- [x] Implement de-duplication and throttling *(listener hash guard, repository Flow backpressure)*
 - [ ] Unit tests with MockK
 
 ### Phase 2.3: Backend Relay - Core
-- [ ] Initialize Rust project with Actix-web
-- [ ] Implement WebSocket handler
-- [ ] Implement Redis connection pool
-- [ ] Device registration/unregistration
-- [ ] Message routing logic
-- [ ] Health check endpoint
+- [x] Initialize Rust project with Actix-web
+- [x] Implement WebSocket handler
+- [x] Implement Redis connection pool
+- [x] Device registration/unregistration
+- [x] Message routing logic
+- [x] Health check endpoint
 - [ ] Unit tests for routing logic
 
 ---
@@ -106,27 +113,27 @@ Last Updated: October 1, 2025
 ## Sprint 4: Content Type Handling (Weeks 7-8)
 
 ### Phase 4.1: Text & Links
-- [ ] macOS: Extract text from NSPasteboard
+- [x] macOS: Extract text from NSPasteboard
 - [ ] Android: Extract text from ClipData
-- [ ] URL validation and link detection
-- [ ] Preview generation (first 100 chars)
+- [x] URL validation and link detection
+- [x] Preview generation (first 100 chars)
 - [ ] End-to-end test: text sync
 
 ### Phase 4.2: Images
-- [ ] macOS: Extract image from NSPasteboard
-- [ ] macOS: Compress to PNG/JPEG if >1MB
-- [ ] macOS: Generate thumbnail for history
+- [x] macOS: Extract image from NSPasteboard
+- [x] macOS: Compress to PNG/JPEG if >1MB
+- [x] macOS: Generate thumbnail for history
 - [ ] Android: Extract bitmap from ClipData
 - [ ] Android: Compress and encode to Base64
 - [ ] Android: Generate thumbnail
 - [ ] End-to-end test: image sync
 
 ### Phase 4.3: Files
-- [ ] macOS: Extract file URL from NSPasteboard
-- [ ] macOS: Read file bytes, encode Base64
+- [x] macOS: Extract file URL from NSPasteboard
+- [x] macOS: Read file bytes, encode Base64
 - [ ] Android: Extract file URI from ClipData
 - [ ] Android: Read content resolver, encode Base64
-- [ ] Implement size limit checks (1MB)
+- [x] Implement size limit checks (1MB)
 - [ ] End-to-end test: file sync
 
 ---
@@ -134,23 +141,23 @@ Last Updated: October 1, 2025
 ## Sprint 5: User Interface (Weeks 9-10)
 
 ### Phase 5.1: macOS UI
-- [ ] Create menu bar app with SwiftUI
-- [ ] Implement `MenuBarView` with latest item preview
-- [ ] Implement `HistoryListView` with virtualized scrolling
-- [ ] Implement search bar with real-time filtering
-- [ ] Implement `SettingsView`
-  - [ ] Toggle LAN/Cloud sync
-  - [ ] Set history limit
-  - [ ] Manage paired devices
-  - [ ] View encryption keys
-- [ ] Implement drag-to-paste from history
-- [ ] Dark mode support
-- [ ] Accessibility labels
+- [x] Create menu bar app with SwiftUI
+- [x] Implement `MenuBarView` with latest item preview
+- [x] Implement `HistoryListView` with virtualized scrolling
+- [x] Implement search bar with real-time filtering
+- [x] Implement `SettingsView`
+  - [x] Toggle LAN/Cloud sync
+  - [x] Set history limit
+  - [x] Manage paired devices
+  - [x] View encryption keys
+- [x] Implement drag-to-paste from history
+- [x] Dark mode support
+- [x] Accessibility labels
 
 ### Phase 5.2: Android UI
-- [ ] Create Jetpack Compose app structure
+- [x] Create Jetpack Compose app structure
 - [ ] Implement `HomeScreen` with last item card
-- [ ] Implement `HistoryScreen` with LazyColumn
+- [x] Implement `HistoryScreen` with LazyColumn
 - [ ] Implement search functionality
 - [ ] Implement `SettingsScreen`
   - [ ] Toggle switches for LAN/Cloud
@@ -158,13 +165,13 @@ Last Updated: October 1, 2025
   - [ ] Paired devices management
   - [ ] History retention settings
 - [ ] Material 3 dynamic color support
-- [ ] Implement foreground service notification with actions
+- [ ] Implement foreground service notification with actions *(basic persistent notification in place; add quick actions)*
 
 ### Phase 5.3: Notifications
 - [ ] macOS: Request notification permissions
 - [ ] macOS: Implement rich notifications with thumbnails
 - [ ] macOS: Notification actions (Copy Again, Delete)
-- [ ] Android: Create notification channel
+- [x] Android: Create notification channel
 - [ ] Android: Rich notification with preview
 - [ ] Android: Notification actions
 
@@ -287,9 +294,9 @@ Last Updated: October 1, 2025
 
 ## Notes
 
-- **Blockers**: Document any blockers here
-- **Decisions**: Log major technical decisions
-- **Risks**: Track identified risks and mitigation plans
+- **Blockers**: Await product/stakeholder review of PRD v0.1 before finalizing Sprint 2 backlog scope.
+- **Decisions**: Confirmed LAN-first with cloud fallback transport strategy and JSON messaging per PRD v0.1 & protocol docs.
+- **Risks**: Android/HyperOS background clipboard restrictions and pending encryption library selection could impact schedule (see PRD §8).
 
 ---
 


### PR DESCRIPTION
## Summary
- wrap the macOS clipboard history view model and delegate extension in `canImport(Combine)`/`canImport(AppKit)` guards so the package builds on Linux while retaining UI functionality
- expose the default transport provider publicly so it can be used from default arguments in public initializers

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68dcf928620883258271fd91c4132071

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Android foreground clipboard sync with history, a macOS Swift package with menu bar app and history store, a backend WebSocket session manager with routing, and comprehensive protocol/docs updates including a JSON Schema.
> 
> - **Clients**:
>   - **macOS (Swift Package)**: Add menu bar app shell, `ClipboardMonitor`, `HistoryStore` actor with pin/limit, rate limiter, sync engine scaffolding, transport manager/provider, and unit tests; provide Xcode workspace.
>   - **Android**: Implement foreground `ClipboardSyncService`, clipboard listener with de-dup/ throttling, Room database (`ClipboardEntity`, `ClipboardDao`, converters), repository, Hilt DI, Compose history UI/screens, resources.
> - **Backend**:
>   - **WebSocket**: Enhance handler to register sessions, spawn reader/writer tasks, handle ping/close, and route messages (direct or broadcast) via new `SessionManager`.
>   - **Services**: Add `session_manager` with tests; refine Redis client generics; expose services in `AppState`; minor enum fix (`Ios`).
> - **Docs & Repo**:
>   - Add `docs/protocol.schema.json` and expand `docs/protocol.md` (schema reference, error catalogue, retry guidance).
>   - Add `docs/crypto_research.md`, `docs/prd.md`; update `README.md`, `status.md`, `tasks.md`, `changelog.md` (build verification, progress, roadmap).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0088d276b831e08cf61541dacb80eb5e7e9c3cf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->